### PR TITLE
fix: guard time.tzset() call for Windows compatibility

### DIFF
--- a/utils/config.py
+++ b/utils/config.py
@@ -41,8 +41,9 @@ class ExpConfig:
     timestamp: str | None = None
 
     def __post_init__(self):
-        os.environ["TZ"] = "America/Los_Angeles" # set the timezone as you like
-        time.tzset()  # Only needed once after setting TZ
+        os.environ["TZ"] = "America/Los_Angeles"  # set the timezone as you like
+        if hasattr(time, "tzset"):
+            time.tzset()  # Only available on Unix; no-op guard for Windows
         
         # Fallback to yaml config if no model_name provided
         if not self.model_name or not self.image_model_name:


### PR DESCRIPTION
## Description

`time.tzset()` is only available on Unix systems. On Windows, calling it raises `AttributeError`, preventing the application from starting entirely.

This wraps the call in a `hasattr` check so the `TZ` environment variable is still set (which many libraries respect on Windows) while avoiding the crash.

Fixes #16

## Changes

- `utils/config.py`: Added `hasattr(time, 'tzset')` guard before calling `time.tzset()`

## Testing

Verified that the guard correctly skips the call when `tzset` is not available (Windows) and still calls it when available (Unix).