### PR TITLE
feat: Auto-generate model_config.yaml as a fallback in demo.py

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -33,6 +33,15 @@ from datetime import datetime
 sys.path.insert(0, str(Path(__file__).parent))
 
 print("DEBUG: Importing agents...")
+import yaml
+import shutil
+configs_dir = Path(__file__).parent / "configs"
+config_path = configs_dir / "model_config.yaml"
+template_path = configs_dir / "model_config.template.yaml"
+
+if not config_path.exists() and template_path.exists():
+    print(f"DEBUG: {config_path.name} not found. Auto-generating from template")
+    shutil.copy2(template_path, config_path)
 try:
     from agents.planner_agent import PlannerAgent
     print("DEBUG: Imported PlannerAgent")
@@ -47,8 +56,6 @@ try:
     from utils.paperviz_processor import PaperVizProcessor
     print("DEBUG: Imported utils")
 
-    import yaml
-    config_path = Path(__file__).parent / "configs" / "model_config.yaml"
     model_config_data = {}
     if config_path.exists():
         with open(config_path, "r", encoding="utf-8") as f:


### PR DESCRIPTION
   ## Description
This PR improves the out-of-the-box experience by automatically generating `model_config.yaml` from the template if the user forgets to create it manually before running `demo.py`.

## Motivation & Context
According to **Step 2: Configuration** in the README, users are instructed to duplicate `configs/model_config.template.yaml` into `configs/model_config.yaml`.

However, if a user misses this step and runs `demo.py` directly, they immediately face a wall of warnings:
  Warning: Could not initialize Gemini Client. Missing credentials.
  Warning: Could not initialize Anthropic Client. Missing credentials.
  Warning: Could not initialize OpenAI Client. Missing credentials.


This happens because the agent modules are imported (and initialized) *before* checking if the configuration file even exists.

## What Changed
* Added a convenience fallback logic that automatically copies `model_config.template.yaml` to `model_config.yaml` if it doesn't exist.
* Crucially, **moved this logic to execute BEFORE importing the `agents` and `utils` modules**.
* This ensures that if the user forgot the setup step, the template is copied first, preventing the premature
     "Missing credentials" warning spam during module initialization.