### PR TITLE
Estimated price , Load historical dialogues , Third-party API key sup…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 .venv/
 data/
 results/
+paperbanana-0.1.0

--- a/agents/critic_agent.py
+++ b/agents/critic_agent.py
@@ -122,7 +122,7 @@ class CriticAgent(BaseAgent):
                 candidate_count=1,
                 max_output_tokens=50000,
             ),
-            max_attempts=5,
+            max_attempts=max(1, int(data.get("text_model_max_attempts", 5))),
             retry_delay=5,
         )
         

--- a/agents/planner_agent.py
+++ b/agents/planner_agent.py
@@ -71,6 +71,8 @@ class PlannerAgent(BaseAgent):
                 candidate_pool = json.load(f)
             id_to_item = {item["id"]: item for item in candidate_pool}
             examples = [id_to_item[ref_id] for ref_id in retrieved_ids if ref_id in id_to_item]
+        max_reference_examples = max(0, int(data.get("max_reference_examples", 10)))
+        examples = examples[:max_reference_examples]
         
         user_prompt = ""
         for idx, item in enumerate(examples):
@@ -109,7 +111,7 @@ class PlannerAgent(BaseAgent):
                 candidate_count=1,
                 max_output_tokens=50000,
             ),
-            max_attempts=5,
+            max_attempts=max(1, int(data.get("text_model_max_attempts", 5))),
             retry_delay=5,
         )
         
@@ -138,4 +140,3 @@ To help you understand the task better, and grasp the principles for generating 
 ** IMPORTANT: **
 Your description should be as detailed as possible. For content, explain the precise mapping of variables to visual channels (x, y, hue) and explicitly enumerate every raw data point's coordinate to be drawn to ensure accuracy. For presentation, specify the exact aesthetic parameters, including specific HEX color codes, font sizes for all labels, line widths, marker dimensions, legend placement, and grid styles. You should learn from the examples' content presentation and aesthetic design (e.g., color schemes).
 """
-

--- a/agents/retriever_agent.py
+++ b/agents/retriever_agent.py
@@ -87,6 +87,8 @@ class RetrieverAgent(BaseAgent):
                 print(f"Warning: Manual reference file not found at {manual_file}. Falling back to retrieval_setting='none'.")
                 retrieval_setting = "none"
         
+        max_reference_examples = max(0, int(data.get("max_reference_examples", 10)))
+
         if retrieval_setting == "none":
             # No retrieval, return empty list
             data["top10_references"] = []
@@ -109,6 +111,11 @@ class RetrieverAgent(BaseAgent):
             data["retrieved_examples"] = []  # Planner will load from ref.json
         else:
             raise ValueError(f"Unknown retrieval_setting: {retrieval_setting}")
+
+        if max_reference_examples >= 0:
+            data["top10_references"] = data.get("top10_references", [])[:max_reference_examples]
+            if "retrieved_examples" in data:
+                data["retrieved_examples"] = data.get("retrieved_examples", [])[:max_reference_examples]
         
         return data
     
@@ -147,8 +154,10 @@ class RetrieverAgent(BaseAgent):
         
         with open(self.exp_config.work_dir / f"data/PaperBananaBench/{cfg['task_name']}/ref.json", "r", encoding="utf-8") as f:
             candidate_pool = json.load(f)
+            candidate_pool_limit = int(data.get("retrieval_candidate_pool_limit", cfg["ref_limit"] or len(candidate_pool)))
             if cfg["ref_limit"]:
-                candidate_pool = candidate_pool[:cfg["ref_limit"]]
+                candidate_pool_limit = min(candidate_pool_limit, cfg["ref_limit"])
+            candidate_pool = candidate_pool[:candidate_pool_limit]
         
         for idx, item in enumerate(candidate_pool):
             user_prompt += f"Candidate {cfg['candidate_type']} {idx+1}:\n"
@@ -168,7 +177,7 @@ class RetrieverAgent(BaseAgent):
                 candidate_count=1,
                 max_output_tokens=50000,
             ),
-            max_attempts=5,
+            max_attempts=max(1, int(data.get("text_model_max_attempts", 5))),
             retry_delay=30,
         )
         
@@ -336,4 +345,3 @@ Provide your output strictly in the following JSON format, containing only the *
   ]
 }```
 """
-

--- a/agents/stylist_agent.py
+++ b/agents/stylist_agent.py
@@ -84,7 +84,7 @@ class StylistAgent(BaseAgent):
                 candidate_count=1,
                 max_output_tokens=50000,
             ),
-            max_attempts=5,
+            max_attempts=max(1, int(data.get("text_model_max_attempts", 5))),
             retry_delay=5,
         )
         

--- a/agents/visualizer_agent.py
+++ b/agents/visualizer_agent.py
@@ -137,6 +137,8 @@ class VisualizerAgent(BaseAgent):
         
         if not cfg["use_image_generation"]:
             loop = asyncio.get_running_loop()
+        image_model_max_attempts = max(1, int(data.get("image_model_max_attempts", 5)))
+        text_model_max_attempts = max(1, int(data.get("text_model_max_attempts", 5)))
         
         for desc_key in desc_keys_to_process:
             prompt_text = cfg["prompt_template"].format(desc=data[desc_key])
@@ -166,7 +168,21 @@ class VisualizerAgent(BaseAgent):
                         model_name=self.model_name,
                         prompt=prompt_text,
                         config=image_config,
-                        max_attempts=5,
+                        max_attempts=image_model_max_attempts,
+                        retry_delay=30,
+                    )
+                elif generation_utils.should_use_openai_compatible_image_generation(self.model_name):
+                    image_config = {
+                        "system_prompt": self.system_prompt,
+                        "temperature": self.exp_config.temperature,
+                        "aspect_ratio": aspect_ratio,
+                        "image_size": "1k",
+                    }
+                    response_list = await generation_utils.call_openai_compatible_image_generation_with_retry_async(
+                        model_name=self.model_name,
+                        contents=content_list,
+                        config=image_config,
+                        max_attempts=image_model_max_attempts,
                         retry_delay=30,
                     )
                 elif generation_utils.openrouter_client is not None:
@@ -181,7 +197,7 @@ class VisualizerAgent(BaseAgent):
                         model_name=self.model_name,
                         contents=content_list,
                         config=image_config,
-                        max_attempts=5,
+                        max_attempts=image_model_max_attempts,
                         retry_delay=30,
                     )
                 else:
@@ -195,7 +211,7 @@ class VisualizerAgent(BaseAgent):
                         model_name=self.model_name,
                         contents=content_list,
                         config=types.GenerateContentConfig(**gen_config_args),
-                        max_attempts=5,
+                        max_attempts=image_model_max_attempts,
                         retry_delay=30,
                     )
             else:
@@ -204,11 +220,11 @@ class VisualizerAgent(BaseAgent):
                     model_name=self.model_name,
                     contents=content_list,
                     config=types.GenerateContentConfig(**gen_config_args),
-                    max_attempts=5,
+                    max_attempts=text_model_max_attempts,
                     retry_delay=30,
                 )
             
-            if not response_list or not response_list[0]:
+            if not response_list or not response_list[0] or response_list[0] == "Error":
                 continue
             
             # Post-process based on task type

--- a/demo.py
+++ b/demo.py
@@ -32,7 +32,6 @@ from datetime import datetime
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent))
 
-print("DEBUG: Importing agents...")
 import yaml
 import shutil
 configs_dir = Path(__file__).parent / "configs"
@@ -40,21 +39,17 @@ config_path = configs_dir / "model_config.yaml"
 template_path = configs_dir / "model_config.template.yaml"
 
 if not config_path.exists() and template_path.exists():
-    print(f"DEBUG: {config_path.name} not found. Auto-generating from template")
     shutil.copy2(template_path, config_path)
 try:
     from agents.planner_agent import PlannerAgent
-    print("DEBUG: Imported PlannerAgent")
     from agents.visualizer_agent import VisualizerAgent
     from agents.stylist_agent import StylistAgent
     from agents.critic_agent import CriticAgent
     from agents.retriever_agent import RetrieverAgent
     from agents.vanilla_agent import VanillaAgent
     from agents.polish_agent import PolishAgent
-    print("DEBUG: Imported all agents")
     from utils import config
     from utils.paperviz_processor import PaperVizProcessor
-    print("DEBUG: Imported utils")
 
     model_config_data = {}
     if config_path.exists():
@@ -68,12 +63,10 @@ try:
         return val or default
 
 except ImportError as e:
-    print(f"DEBUG: ImportError: {e}")
     import traceback
     traceback.print_exc()
     raise e
 except Exception as e:
-    print(f"DEBUG: Exception during import: {e}")
     import traceback
     traceback.print_exc()
     raise e
@@ -105,7 +98,18 @@ def base64_to_image(b64_str):
     except Exception:
         return None
 
-def create_sample_inputs(method_content, caption, diagram_type="Pipeline", aspect_ratio="16:9", num_copies=10, max_critic_rounds=3):
+def create_sample_inputs(
+    method_content,
+    caption,
+    diagram_type="Pipeline",
+    aspect_ratio="16:9",
+    num_copies=10,
+    max_critic_rounds=3,
+    max_reference_examples=10,
+    retrieval_candidate_pool_limit=200,
+    text_model_max_attempts=5,
+    image_model_max_attempts=5,
+):
     """Create multiple copies of the input data for parallel processing."""
     base_input = {
         "filename": "demo_input",
@@ -115,7 +119,11 @@ def create_sample_inputs(method_content, caption, diagram_type="Pipeline", aspec
         "additional_info": {
             "rounded_ratio": aspect_ratio
         },
-        "max_critic_rounds": max_critic_rounds  # Add critic rounds control
+        "max_critic_rounds": max_critic_rounds,
+        "max_reference_examples": max_reference_examples,
+        "retrieval_candidate_pool_limit": retrieval_candidate_pool_limit,
+        "text_model_max_attempts": text_model_max_attempts,
+        "image_model_max_attempts": image_model_max_attempts,
     }
     
     # Create num_copies identical inputs, each with a unique identifier
@@ -128,7 +136,14 @@ def create_sample_inputs(method_content, caption, diagram_type="Pipeline", aspec
     
     return inputs
 
-async def process_parallel_candidates(data_list, exp_mode="dev_planner_critic", retrieval_setting="auto", main_model_name="", image_gen_model_name=""):
+async def process_parallel_candidates(
+    data_list,
+    exp_mode="dev_planner_critic",
+    retrieval_setting="auto",
+    main_model_name="",
+    image_gen_model_name="",
+    max_concurrent=3,
+):
     """Process multiple candidates in parallel using PaperVizProcessor."""
     # Create experiment config
     exp_config = config.ExpConfig(
@@ -155,7 +170,7 @@ async def process_parallel_candidates(data_list, exp_mode="dev_planner_critic", 
     
     # Process all candidates in parallel (concurrency controlled by processor)
     results = []
-    concurrent_num = 10  # Process all 10 in parallel
+    concurrent_num = max(1, min(max_concurrent, len(data_list)))
     
     async for result_data in processor.process_queries_batch(
         data_list, max_concurrent=concurrent_num, do_eval=False
@@ -184,7 +199,48 @@ async def refine_image_with_nanoviz(image_bytes, edit_prompt, aspect_ratio="21:9
     image_b64 = base64.b64encode(image_bytes).decode("utf-8")
     image_data_url = f"data:image/jpeg;base64,{image_b64}"
 
-    # --- Path 1: OpenRouter (preferred, matches main pipeline priority) ---
+    # --- Path 1: OpenAI-compatible chat/completions (custom third-party gateway) ---
+    try:
+        from utils.generation_utils import (
+            call_openai_compatible_image_generation_with_retry_async,
+            should_use_openai_compatible_image_generation,
+        )
+        _has_openai_compat_image = True
+    except ImportError:
+        _has_openai_compat_image = False
+    openai_api_key = get_config_val("api_keys", "openai_api_key", "OPENAI_API_KEY", "")
+    openai_base_url = get_config_val("api_endpoints", "openai_base_url", "OPENAI_BASE_URL", "")
+    if (
+        _has_openai_compat_image
+        and openai_api_key
+        and openai_base_url
+        and should_use_openai_compatible_image_generation(image_model)
+    ):
+        try:
+            contents = [
+                {"type": "image", "data": image_b64, "mime_type": "image/jpeg"},
+                {"type": "text", "text": edit_prompt},
+            ]
+            config = {
+                "system_prompt": "",
+                "temperature": 1.0,
+                "aspect_ratio": aspect_ratio,
+                "image_size": image_size,
+            }
+            result = await call_openai_compatible_image_generation_with_retry_async(
+                model_name=image_model,
+                contents=contents,
+                config=config,
+                max_attempts=3,
+                retry_delay=10,
+                error_context="refine_image",
+            )
+            if result and result[0] != "Error":
+                return base64.b64decode(result[0]), "✅ Image refined successfully! (via OpenAI-compatible gateway)"
+        except Exception as e:
+            print(f"OpenAI-compatible refine failed: {e}, falling back to OpenRouter/Google API key...")
+
+    # --- Path 2: OpenRouter (preferred when explicitly configured) ---
     try:
         from utils.generation_utils import call_openrouter_image_generation_with_retry_async
         _has_openrouter = True
@@ -216,7 +272,7 @@ async def refine_image_with_nanoviz(image_bytes, edit_prompt, aspect_ratio="21:9
         except Exception as e:
             print(f"OpenRouter refine failed: {e}, falling back to Google API key...")
 
-    # --- Path 2 & 3: Gemini native SDK (Google API key or Vertex AI ADC) ---
+    # --- Path 3 & 4: Gemini native SDK (Google API key or Vertex AI ADC) ---
     try:
         from google import genai
         from google.genai import types
@@ -234,7 +290,7 @@ async def refine_image_with_nanoviz(image_bytes, edit_prompt, aspect_ratio="21:9
         client = genai.Client(vertexai=True, project=project_id, location=location)
         via = "Vertex AI"
     else:
-        return None, "❌ Error: No API credentials configured. Set OPENROUTER_API_KEY, GOOGLE_API_KEY, or configure Vertex AI project in configs/model_config.yaml."
+        return None, "❌ Error: No API credentials configured. Set OPENAI_API_KEY + OPENAI_BASE_URL, OPENROUTER_API_KEY, GOOGLE_API_KEY, or configure Vertex AI project in configs/model_config.yaml."
 
     try:
         contents = [
@@ -408,6 +464,135 @@ def display_candidate_result(result, candidate_id, exp_mode):
             else:
                 st.info("No description available")
 
+
+def estimate_generation_usage(
+    exp_mode,
+    retrieval_setting,
+    num_candidates,
+    max_critic_rounds,
+    text_model_max_attempts,
+    image_model_max_attempts,
+    max_reference_examples,
+    retrieval_candidate_pool_limit,
+):
+    """Estimate model call counts and worst-case retry-expanded attempts."""
+    candidates = max(1, int(num_candidates))
+    rounds = max(0, int(max_critic_rounds))
+    has_retrieval = retrieval_setting != "none" and int(max_reference_examples) > 0
+
+    retrieval_calls = 1 if has_retrieval else 0
+    planner_calls = candidates
+    stylist_calls = candidates if exp_mode == "demo_full" else 0
+
+    if exp_mode in ("demo_planner_critic", "demo_full"):
+        critic_calls_min = candidates if rounds > 0 else 0
+        critic_calls_max = candidates * rounds
+        image_calls_min = candidates
+        image_calls_max = candidates * (1 + rounds)
+    else:
+        critic_calls_min = 0
+        critic_calls_max = 0
+        image_calls_min = candidates
+        image_calls_max = candidates
+
+    text_calls_min = retrieval_calls + planner_calls + stylist_calls + critic_calls_min
+    text_calls_max = retrieval_calls + planner_calls + stylist_calls + critic_calls_max
+    total_calls_min = text_calls_min + image_calls_min
+    total_calls_max = text_calls_max + image_calls_max
+
+    worst_case_attempts_min = (
+        retrieval_calls * int(text_model_max_attempts)
+        + (planner_calls + stylist_calls + critic_calls_min) * int(text_model_max_attempts)
+        + image_calls_min * int(image_model_max_attempts)
+    )
+    worst_case_attempts_max = (
+        retrieval_calls * int(text_model_max_attempts)
+        + (planner_calls + stylist_calls + critic_calls_max) * int(text_model_max_attempts)
+        + image_calls_max * int(image_model_max_attempts)
+    )
+
+    return {
+        "retrieval_calls": retrieval_calls,
+        "planner_calls": planner_calls,
+        "stylist_calls": stylist_calls,
+        "critic_calls_min": critic_calls_min,
+        "critic_calls_max": critic_calls_max,
+        "image_calls_min": image_calls_min,
+        "image_calls_max": image_calls_max,
+        "text_calls_min": text_calls_min,
+        "text_calls_max": text_calls_max,
+        "total_calls_min": total_calls_min,
+        "total_calls_max": total_calls_max,
+        "worst_case_attempts_min": worst_case_attempts_min,
+        "worst_case_attempts_max": worst_case_attempts_max,
+        "reference_examples": int(max_reference_examples),
+        "retrieval_candidate_pool_limit": int(retrieval_candidate_pool_limit),
+    }
+
+
+def infer_exp_mode_from_results(results):
+    """Best-effort inference for older saved JSON files that only store results."""
+    if not results:
+        return "dev_planner"
+    sample = results[0]
+    if "target_diagram_stylist_desc0" in sample:
+        return "demo_full"
+    if any(k.startswith("target_diagram_critic_desc") for k in sample):
+        return "demo_planner_critic"
+    return "dev_planner"
+
+
+def infer_timestamp_from_filename(file_path: Path) -> str:
+    """Convert demo_YYYYMMDD_HHMMSS.json into a readable timestamp if possible."""
+    stem = file_path.stem
+    prefix = "demo_"
+    if not stem.startswith(prefix):
+        return stem
+    raw = stem[len(prefix):]
+    try:
+        return datetime.strptime(raw, "%Y%m%d_%H%M%S").strftime("%Y-%m-%d %H:%M:%S")
+    except ValueError:
+        return raw
+
+
+def load_saved_results(file_path: Path):
+    """Load saved results from disk, supporting both list-only and wrapped metadata formats."""
+    with open(file_path, "r", encoding="utf-8") as f:
+        payload = json.load(f)
+
+    if isinstance(payload, list):
+        results = payload
+        metadata = {}
+    elif isinstance(payload, dict):
+        results = payload.get("results", [])
+        metadata = payload.get("metadata", {})
+    else:
+        raise ValueError("Saved JSON must be a list or an object with 'results'.")
+
+    if not isinstance(results, list):
+        raise ValueError("Saved results payload has invalid format.")
+
+    exp_mode = metadata.get("exp_mode") or infer_exp_mode_from_results(results)
+    timestamp = metadata.get("timestamp") or infer_timestamp_from_filename(file_path)
+    method_content = metadata.get("method_content")
+    caption = metadata.get("caption")
+    if results:
+        first = results[0]
+        if method_content is None:
+            method_content = first.get("content", "")
+        if caption is None:
+            caption = first.get("caption", "")
+
+    return {
+        "results": results,
+        "exp_mode": exp_mode,
+        "timestamp": timestamp,
+        "method_content": method_content or "",
+        "caption": caption or "",
+        "json_file": str(file_path),
+    }
+
+
 def main():
     st.title("🍌 PaperVizAgent Demo")
     st.markdown("AI-powered scientific diagram generation and refinement")
@@ -425,17 +610,25 @@ def main():
             
             exp_mode = st.selectbox(
                 "Pipeline Mode",
-                ["demo_full", "demo_planner_critic"],
+                ["dev_planner", "demo_planner_critic", "demo_full"],
                 index=0,
                 key="tab1_exp_mode",
                 help="Select which agent pipeline to use"
             )
             
             mode_info = {
+                "dev_planner": "Retriever → Planner → Visualizer. Lowest-cost path with a single image generation call.",
                 "demo_planner_critic": "Planner → Visualizer → Critic → Visualizer",
                 "demo_full": "Retriever → Planner → Stylist → Visualizer → Critic → Visualizer. (The stylist can make the diagram more aesthetically pleasing, but prone to be overly simplied. So we recommend trying both modes and select the best one)"
             }
             st.info(f"**Pipeline:** {mode_info[exp_mode]}")
+
+            budget_mode = st.checkbox(
+                "Budget Mode",
+                value=True,
+                key="tab1_budget_mode",
+                help="Reduce token and image spend by using fewer references, fewer retries, and fewer critic rounds"
+            )
             
             retrieval_setting = st.selectbox(
                 "Retrieval Setting",
@@ -449,9 +642,19 @@ def main():
                 "Number of Candidates",
                 min_value=1,
                 max_value=20,
-                value=10,
+                value=1,
                 key="tab1_num_candidates",
                 help="How many parallel candidates to generate"
+            )
+
+            default_max_concurrent = 1 if budget_mode else min(3, int(num_candidates))
+            max_concurrent = st.number_input(
+                "Max Concurrent Requests",
+                min_value=1,
+                max_value=int(num_candidates),
+                value=default_max_concurrent,
+                key="tab1_max_concurrent",
+                help="Lower this when using a third-party API gateway that times out under heavy parallel load"
             )
             
             aspect_ratio = st.selectbox(
@@ -463,11 +666,48 @@ def main():
             
             max_critic_rounds = st.number_input(
                 "Max Critic Rounds",
-                min_value=1,
+                min_value=0,
                 max_value=5,
-                value=3,
+                value=1 if budget_mode else 3,
                 key="tab1_max_critic_rounds",
                 help="Maximum number of critic refinement iterations"
+            )
+
+            max_reference_examples = st.number_input(
+                "Reference Examples Used",
+                min_value=0,
+                max_value=10,
+                value=3 if budget_mode else 10,
+                key="tab1_max_reference_examples",
+                help="How many retrieved references the Planner sees. Lower values save tokens."
+            )
+
+            retrieval_candidate_pool_limit = st.number_input(
+                "Retriever Candidate Pool Limit",
+                min_value=10,
+                max_value=200,
+                value=50 if budget_mode else 200,
+                step=10,
+                key="tab1_retrieval_candidate_pool_limit",
+                help="How many reference candidates are shown to the Retriever. Lower values save tokens."
+            )
+
+            text_model_max_attempts = st.number_input(
+                "Text Model Retry Attempts",
+                min_value=1,
+                max_value=5,
+                value=2 if budget_mode else 5,
+                key="tab1_text_model_max_attempts",
+                help="Retries for Planner/Stylist/Critic/Retriever"
+            )
+
+            image_model_max_attempts = st.number_input(
+                "Image Model Retry Attempts",
+                min_value=1,
+                max_value=5,
+                value=2 if budget_mode else 5,
+                key="tab1_image_model_max_attempts",
+                help="Retries for image generation calls"
             )
             
             default_model = get_config_val("defaults", "main_model_name", "MAIN_MODEL_NAME", "gemini-3.1-pro-preview")
@@ -517,6 +757,149 @@ def main():
                 )
             else:
                 image_gen_model_name = image_model_selection
+
+            usage_preview = estimate_generation_usage(
+                exp_mode=exp_mode,
+                retrieval_setting=("none" if int(max_reference_examples) == 0 else retrieval_setting),
+                num_candidates=num_candidates,
+                max_critic_rounds=max_critic_rounds,
+                text_model_max_attempts=text_model_max_attempts,
+                image_model_max_attempts=image_model_max_attempts,
+                max_reference_examples=max_reference_examples,
+                retrieval_candidate_pool_limit=retrieval_candidate_pool_limit,
+            )
+
+            st.divider()
+            st.markdown("### Cost Preview")
+            st.caption(
+                f"Prompt size scales with {usage_preview['reference_examples']} reference examples "
+                f"and a retriever pool of {usage_preview['retrieval_candidate_pool_limit']} candidates."
+            )
+            st.caption(
+                f"Base model calls: {usage_preview['total_calls_min']}-{usage_preview['total_calls_max']} "
+                f"(text {usage_preview['text_calls_min']}-{usage_preview['text_calls_max']}, "
+                f"image {usage_preview['image_calls_min']}-{usage_preview['image_calls_max']})"
+            )
+            st.caption(
+                f"Worst-case API attempts with retries: "
+                f"{usage_preview['worst_case_attempts_min']}-{usage_preview['worst_case_attempts_max']}"
+            )
+
+            with st.expander("Manual Price Estimate", expanded=False):
+                text_input_price_per_mtok = st.number_input(
+                    "Text Input Price / 1M Tok (USD)",
+                    min_value=0.0,
+                    value=0.0,
+                    step=0.001,
+                    format="%.3f",
+                    key="tab1_text_input_price_per_mtok",
+                    help="Optional. Enter your third-party provider's input-token price."
+                )
+                text_output_price_per_mtok = st.number_input(
+                    "Text Output Price / 1M Tok (USD)",
+                    min_value=0.0,
+                    value=0.0,
+                    step=0.001,
+                    format="%.3f",
+                    key="tab1_text_output_price_per_mtok",
+                    help="Optional. Enter your third-party provider's output-token price."
+                )
+                avg_text_input_tokens = st.number_input(
+                    "Avg Input Tokens / Text Call",
+                    min_value=0,
+                    value=4000,
+                    step=500,
+                    key="tab1_avg_text_input_tokens",
+                    help="Manual estimate for average prompt size per text-model call."
+                )
+                avg_text_output_tokens = st.number_input(
+                    "Avg Output Tokens / Text Call",
+                    min_value=0,
+                    value=1200,
+                    step=100,
+                    key="tab1_avg_text_output_tokens",
+                    help="Manual estimate for average completion size per text-model call."
+                )
+                image_price_per_call = st.number_input(
+                    "Image Call Price (USD)",
+                    min_value=0.0,
+                    value=0.0,
+                    step=0.001,
+                    format="%.3f",
+                    key="tab1_image_price_per_call",
+                    help="Optional. Enter your third-party provider's estimated price per image generation call."
+                )
+                if (
+                    text_input_price_per_mtok > 0
+                    or text_output_price_per_mtok > 0
+                    or image_price_per_call > 0
+                ):
+                    text_cost_per_call = (
+                        (avg_text_input_tokens / 1_000_000) * text_input_price_per_mtok
+                        + (avg_text_output_tokens / 1_000_000) * text_output_price_per_mtok
+                    )
+                    base_cost_min = (
+                        usage_preview["text_calls_min"] * text_cost_per_call
+                        + usage_preview["image_calls_min"] * image_price_per_call
+                    )
+                    base_cost_max = (
+                        usage_preview["text_calls_max"] * text_cost_per_call
+                        + usage_preview["image_calls_max"] * image_price_per_call
+                    )
+                    retry_cost_min = (
+                        usage_preview["text_calls_min"] * text_model_max_attempts * text_cost_per_call
+                        + usage_preview["image_calls_min"] * image_model_max_attempts * image_price_per_call
+                    )
+                    retry_cost_max = (
+                        usage_preview["text_calls_max"] * text_model_max_attempts * text_cost_per_call
+                        + usage_preview["image_calls_max"] * image_model_max_attempts * image_price_per_call
+                    )
+                    est_text_input_min = usage_preview["text_calls_min"] * avg_text_input_tokens
+                    est_text_input_max = usage_preview["text_calls_max"] * avg_text_input_tokens
+                    est_text_output_min = usage_preview["text_calls_min"] * avg_text_output_tokens
+                    est_text_output_max = usage_preview["text_calls_max"] * avg_text_output_tokens
+                    st.caption(
+                        f"Estimated text tokens: input {est_text_input_min:,}-{est_text_input_max:,}, "
+                        f"output {est_text_output_min:,}-{est_text_output_max:,}"
+                    )
+                    st.caption(f"Base run estimate: ${base_cost_min:.3f}-${base_cost_max:.3f}")
+                    st.caption(f"Worst-case with retries: ${retry_cost_min:.3f}-${retry_cost_max:.3f}")
+
+            st.divider()
+            st.markdown("### Load Saved Results")
+            saved_results_dir = Path(__file__).parent / "results" / "demo"
+            saved_result_files = sorted(saved_results_dir.glob("demo_*.json"), reverse=True)
+            saved_result_labels = ["None"]
+            saved_result_map = {"None": None}
+            for file_path in saved_result_files:
+                label = f"{file_path.name} ({infer_timestamp_from_filename(file_path)})"
+                saved_result_labels.append(label)
+                saved_result_map[label] = file_path
+
+            selected_saved_result = st.selectbox(
+                "Saved Result File",
+                saved_result_labels,
+                index=0,
+                key="tab1_saved_result_file",
+                help="Load a previously generated demo JSON from results/demo"
+            )
+            if st.button("Load Saved Results", use_container_width=True, key="tab1_load_saved_results"):
+                selected_path = saved_result_map.get(selected_saved_result)
+                if selected_path is None:
+                    st.warning("Please select a saved result file first.")
+                else:
+                    try:
+                        loaded = load_saved_results(selected_path)
+                        st.session_state["results"] = loaded["results"]
+                        st.session_state["exp_mode"] = loaded["exp_mode"]
+                        st.session_state["timestamp"] = loaded["timestamp"]
+                        st.session_state["json_file"] = loaded["json_file"]
+                        st.session_state["method_content"] = loaded["method_content"]
+                        st.session_state["caption"] = loaded["caption"]
+                        st.success(f"Loaded {selected_path.name}")
+                        st.rerun()
+                    except Exception as e:
+                        st.error(f"Failed to load saved results: {e}")
         
         st.divider()
         
@@ -632,13 +1015,21 @@ The framework extends to statistical plots by adjusting the Visualizer and Criti
                 st.session_state["caption"] = caption
                 
                 with st.spinner(f"Generating {num_candidates} candidates in parallel... This may take a few minutes."):
+                    effective_retrieval_setting = retrieval_setting
+                    if int(max_reference_examples) == 0:
+                        effective_retrieval_setting = "none"
+
                     # Create input data list
                     input_data_list = create_sample_inputs(
                         method_content=method_content,
                         caption=caption,
                         aspect_ratio=aspect_ratio,
                         num_copies=num_candidates,
-                        max_critic_rounds=max_critic_rounds
+                        max_critic_rounds=max_critic_rounds,
+                        max_reference_examples=int(max_reference_examples),
+                        retrieval_candidate_pool_limit=int(retrieval_candidate_pool_limit),
+                        text_model_max_attempts=int(text_model_max_attempts),
+                        image_model_max_attempts=int(image_model_max_attempts),
                     )
                     
                     # Process in parallel
@@ -646,9 +1037,10 @@ The framework extends to statistical plots by adjusting the Visualizer and Criti
                         results = asyncio.run(process_parallel_candidates(
                             input_data_list,
                             exp_mode=exp_mode,
-                            retrieval_setting=retrieval_setting,
+                            retrieval_setting=effective_retrieval_setting,
                             main_model_name=main_model_name,
-                            image_gen_model_name=image_gen_model_name
+                            image_gen_model_name=image_gen_model_name,
+                            max_concurrent=int(max_concurrent),
                         ))
                         st.session_state["results"] = results
                         st.session_state["exp_mode"] = exp_mode
@@ -663,10 +1055,19 @@ The framework extends to statistical plots by adjusting the Visualizer and Criti
                             
                             # Generate filename with timestamp
                             json_filename = results_dir / f"demo_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+                            save_payload = {
+                                "metadata": {
+                                    "timestamp": timestamp_str,
+                                    "exp_mode": exp_mode,
+                                    "method_content": method_content,
+                                    "caption": caption,
+                                },
+                                "results": results,
+                            }
                             
                             # Save to JSON with proper encoding handling (like main.py)
                             with open(json_filename, "w", encoding="utf-8", errors="surrogateescape") as f:
-                                json_string = json.dumps(results, ensure_ascii=False, indent=4)
+                                json_string = json.dumps(save_payload, ensure_ascii=False, indent=4)
                                 # Clean invalid UTF-8 characters
                                 json_string = json_string.encode("utf-8", "ignore").decode("utf-8")
                                 f.write(json_string)

--- a/utils/generation_utils.py
+++ b/utils/generation_utils.py
@@ -19,6 +19,7 @@ Utility functions for interacting with Gemini and Claude APIs, image processing,
 import json
 import asyncio
 import base64
+import re
 from io import BytesIO
 from functools import partial
 from ast import literal_eval
@@ -36,6 +37,7 @@ import os
 
 import yaml
 from pathlib import Path
+from urllib.parse import urljoin
 
 # Load config
 config_path = Path(__file__).parent.parent / "configs" / "model_config.yaml"
@@ -49,6 +51,31 @@ def get_config_val(section, key, env_var, default=""):
     if not val and section in model_config:
         val = model_config[section].get(key)
     return val or default
+
+
+def _normalize_proxy_env() -> None:
+    """
+    Normalize proxy environment variables for httpx/openai.
+    Some local proxy tools export `socks://...`, while httpx expects `socks5://` or `socks5h://`.
+    """
+    has_socks_support = True
+    try:
+        import socksio  # noqa: F401
+    except ImportError:
+        has_socks_support = False
+
+    for env_name in ("ALL_PROXY", "all_proxy"):
+        proxy_url = os.environ.get(env_name, "")
+        if proxy_url.startswith("socks://") and has_socks_support:
+            normalized = "socks5://" + proxy_url[len("socks://"):]
+            os.environ[env_name] = normalized
+            print(f"Normalized {env_name} to {normalized}")
+        elif proxy_url.startswith(("socks://", "socks5://", "socks5h://")) and not has_socks_support:
+            os.environ.pop(env_name, None)
+            print(f"Removed {env_name} because SOCKS support is unavailable; falling back to HTTP(S)_PROXY")
+
+
+_normalize_proxy_env()
 
 # Initialize clients lazily or with robust defaults
 api_key = get_config_val("api_keys", "google_api_key", "GOOGLE_API_KEY", "")
@@ -69,9 +96,19 @@ else:
     anthropic_client = None
 
 openai_api_key = get_config_val("api_keys", "openai_api_key", "OPENAI_API_KEY", "")
+openai_base_url = get_config_val("api_endpoints", "openai_base_url", "OPENAI_BASE_URL", None)
 if openai_api_key:
-    openai_client = AsyncOpenAI(api_key=openai_api_key)
-    print("Initialized OpenAI Client with API Key")
+    openai_timeout = float(get_config_val("api_endpoints", "openai_timeout_seconds", "OPENAI_TIMEOUT_SECONDS", "180"))
+    kwargs = {"api_key": openai_api_key, "timeout": openai_timeout}
+    if openai_base_url:
+        kwargs["base_url"] = openai_base_url
+        print(
+            f"Initialized OpenAI Client with API Key and custom base URL: {openai_base_url} "
+            f"(timeout={openai_timeout}s)"
+        )
+    else:
+        print(f"Initialized OpenAI Client with API Key (timeout={openai_timeout}s)")
+    openai_client = AsyncOpenAI(**kwargs)
 else:
     print("Warning: Could not initialize OpenAI Client. Missing credentials.")
     openai_client = None
@@ -257,7 +294,135 @@ def _convert_to_openai_format(contents: List[Dict[str, Any]]) -> List[Dict[str, 
                     "type": "image_url",
                     "image_url": {"url": data_url}
                 })
+            elif "data" in item:
+                media_type = item.get("mime_type", "image/jpeg")
+                data_url = f"data:{media_type};base64,{item['data']}"
+                openai_contents.append({
+                    "type": "image_url",
+                    "image_url": {"url": data_url}
+                })
     return openai_contents
+
+
+def _normalize_openrouter_model_id(model_name: str) -> str:
+    """Normalize OpenRouter model names, accepting an optional openrouter/ prefix."""
+    if model_name.startswith("openrouter/"):
+        model_name = model_name[len("openrouter/"):]
+    if "/" in model_name:
+        return model_name
+    if model_name.startswith("gemini"):
+        return f"google/{model_name}"
+    return model_name
+
+
+def should_use_openai_compatible_image_generation(model_name: str) -> bool:
+    """
+    Route image generation through a custom OpenAI-compatible endpoint when:
+    1. an OpenAI client is configured,
+    2. a non-default base URL is provided,
+    3. the model is an image/chat-completions style model instead of gpt-image.
+    """
+    normalized_model = model_name
+    if normalized_model.startswith("openai/"):
+        normalized_model = normalized_model[len("openai/"):]
+    return (
+        openai_client is not None
+        and bool(openai_base_url)
+        and "gpt-image" not in normalized_model
+        and "image" in normalized_model
+    )
+
+
+def _extract_image_b64_from_chat_completion_response(data: Dict[str, Any]) -> str:
+    """Extract base64 image payload from OpenAI-compatible chat/completions responses."""
+    choices = data.get("choices", [])
+    if not choices:
+        return ""
+
+    message = choices[0].get("message", {})
+    content = message.get("content")
+
+    if isinstance(content, list):
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            if "inline_data" in part:
+                b64_data = part["inline_data"].get("data", "")
+                if b64_data:
+                    return b64_data
+            if part.get("type") == "image":
+                image_obj = part.get("image", {})
+                if isinstance(image_obj, dict):
+                    b64_data = image_obj.get("data", "")
+                    if b64_data:
+                        return b64_data
+            if part.get("type") == "image_url":
+                data_url = part.get("image_url", {}).get("url", "")
+                if data_url:
+                    return data_url.split(",", 1)[1] if "," in data_url else data_url
+
+    images = message.get("images")
+    if images:
+        img_item = images[0]
+        if isinstance(img_item, dict):
+            data_url = img_item.get("image_url", {}).get("url", "")
+        else:
+            data_url = str(img_item)
+        if data_url:
+            return data_url.split(",", 1)[1] if "," in data_url else data_url
+
+    if isinstance(content, str):
+        if content.startswith("data:image"):
+            return content.split(",", 1)[1] if "," in content else content
+        markdown_data_url_match = re.search(r"\(data:image/[^;]+;base64,([A-Za-z0-9+/=\n\r]+)\)", content)
+        if markdown_data_url_match:
+            return "".join(markdown_data_url_match.group(1).split())
+
+    return ""
+
+
+def _summarize_chat_completion_image_response(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a compact, non-base64 summary for debugging image responses."""
+    summary: Dict[str, Any] = {
+        "top_level_keys": list(data.keys())[:10],
+    }
+    choices = data.get("choices", [])
+    summary["choice_count"] = len(choices)
+    if not choices:
+        return summary
+
+    message = choices[0].get("message", {})
+    summary["message_keys"] = list(message.keys())[:10]
+    content = message.get("content")
+    if isinstance(content, list):
+        content_summary = []
+        for part in content[:5]:
+            if not isinstance(part, dict):
+                content_summary.append(type(part).__name__)
+                continue
+            part_summary = {"type": part.get("type")}
+            if "inline_data" in part:
+                part_summary["inline_data_keys"] = list(part["inline_data"].keys())[:10]
+            if "image" in part and isinstance(part["image"], dict):
+                part_summary["image_keys"] = list(part["image"].keys())[:10]
+            if "image_url" in part and isinstance(part["image_url"], dict):
+                part_summary["image_url_keys"] = list(part["image_url"].keys())[:10]
+            content_summary.append(part_summary)
+        summary["content"] = content_summary
+    else:
+        summary["content_type"] = type(content).__name__
+        if isinstance(content, str):
+            summary["content_preview"] = content[:120]
+
+    images = message.get("images")
+    if isinstance(images, list):
+        summary["images_count"] = len(images)
+        if images:
+            first_image = images[0]
+            if isinstance(first_image, dict):
+                summary["first_image_keys"] = list(first_image.keys())[:10]
+
+    return summary
 
 
 async def call_claude_with_retry_async(
@@ -489,6 +654,99 @@ async def call_openai_image_generation_with_retry_async(
     return ["Error"]
 
 
+async def call_openai_compatible_image_generation_with_retry_async(
+    model_name, contents, config, max_attempts=5, retry_delay=30, error_context=""
+):
+    """
+    ASYNC: Call an OpenAI-compatible chat/completions endpoint for image generation.
+    This is used for third-party gateways that expose Gemini image models via /v1/chat/completions.
+    """
+    if not openai_api_key or not openai_base_url:
+        raise RuntimeError(
+            "OpenAI-compatible image generation requires OPENAI_API_KEY and OPENAI_BASE_URL."
+        )
+
+    normalized_model = model_name
+    if normalized_model.startswith("openai/"):
+        normalized_model = normalized_model[len("openai/"):]
+
+    system_prompt = config.get("system_prompt", "")
+    temperature = config.get("temperature", 1.0)
+    aspect_ratio = config.get("aspect_ratio", "1:1")
+    image_size = config.get("image_size", "1k")
+    openai_contents = _convert_to_openai_format(contents)
+
+    payload = {
+        "model": normalized_model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": openai_contents},
+        ],
+        "temperature": temperature,
+        "modalities": ["image", "text"],
+    }
+
+    image_config = {}
+    if aspect_ratio:
+        image_config["aspect_ratio"] = aspect_ratio
+    if image_size:
+        image_config["image_size"] = image_size
+    if image_config:
+        payload["image_config"] = image_config
+
+    headers = {
+        "Authorization": f"Bearer {openai_api_key}",
+        "Content-Type": "application/json",
+    }
+    completions_url = urljoin(openai_base_url.rstrip("/") + "/", "chat/completions")
+
+    for attempt in range(max_attempts):
+        try:
+            async with httpx.AsyncClient(timeout=300) as client:
+                resp = await client.post(completions_url, headers=headers, json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+            b64_data = _extract_image_b64_from_chat_completion_response(data)
+            if b64_data:
+                return [b64_data]
+
+            debug_summary = _summarize_chat_completion_image_response(data)
+            print(
+                "[Warning]: OpenAI-compatible image generation returned no images. "
+                f"Response summary: {json.dumps(debug_summary, ensure_ascii=False)}. Retrying..."
+            )
+            if attempt < max_attempts - 1:
+                await asyncio.sleep(retry_delay)
+
+        except httpx.HTTPStatusError as e:
+            context_msg = f" for {error_context}" if error_context else ""
+            current_delay = min(retry_delay * (2 ** attempt), 60)
+            print(
+                f"OpenAI-compatible image gen attempt {attempt + 1} failed{context_msg}: "
+                f"HTTP {e.response.status_code} - {e.response.text}. "
+                f"Retrying in {current_delay}s..."
+            )
+            if attempt < max_attempts - 1:
+                await asyncio.sleep(current_delay)
+            else:
+                print(f"Error: All {max_attempts} attempts failed{context_msg}")
+                return ["Error"]
+        except Exception as e:
+            context_msg = f" for {error_context}" if error_context else ""
+            current_delay = min(retry_delay * (2 ** attempt), 60)
+            print(
+                f"OpenAI-compatible image gen attempt {attempt + 1} failed{context_msg}: {e}. "
+                f"Retrying in {current_delay}s..."
+            )
+            if attempt < max_attempts - 1:
+                await asyncio.sleep(current_delay)
+            else:
+                print(f"Error: All {max_attempts} attempts failed{context_msg}")
+                return ["Error"]
+
+    return ["Error"]
+
+
 async def call_openrouter_with_retry_async(
     model_name, contents, config, max_attempts=5, retry_delay=30, error_context=""
 ):
@@ -502,7 +760,7 @@ async def call_openrouter_with_retry_async(
             "api_keys.openrouter_api_key in configs/model_config.yaml."
         )
 
-    model_name = _to_openrouter_model_id(model_name)
+    model_name = _normalize_openrouter_model_id(model_name)
     system_prompt = config["system_prompt"]
     temperature = config["temperature"]
     candidate_num = config["candidate_num"]
@@ -649,6 +907,12 @@ async def call_openrouter_image_generation_with_retry_async(
                         b64_data = part["inline_data"].get("data", "")
                         if b64_data:
                             return [b64_data]
+                    if isinstance(part, dict) and part.get("type") == "image":
+                        image_obj = part.get("image", {})
+                        if isinstance(image_obj, dict):
+                            b64_data = image_obj.get("data", "")
+                            if b64_data:
+                                return [b64_data]
 
             # Try extracting from images field (OpenRouter standard)
             images = message.get("images")
@@ -707,17 +971,8 @@ async def call_openrouter_image_generation_with_retry_async(
 
 
 def _to_openrouter_model_id(model_name: str) -> str:
-    """Convert a bare model name to OpenRouter format (provider/model).
-
-    OpenRouter requires model IDs like 'google/gemini-3-pro-preview'.
-    If the name already contains '/', assume it's already qualified.
-    Otherwise, prefix with 'google/' for Gemini models.
-    """
-    if "/" in model_name:
-        return model_name
-    if model_name.startswith("gemini"):
-        return f"google/{model_name}"
-    return model_name
+    """Backward-compatible wrapper for OpenRouter model normalization."""
+    return _normalize_openrouter_model_id(model_name)
 
 
 async def call_model_with_retry_async(
@@ -748,12 +1003,13 @@ async def call_model_with_retry_async(
         if openrouter_client is not None:
             provider = "openrouter"
             actual_model = _to_openrouter_model_id(model_name)
+        elif openai_client is not None:
+            # Use OpenAI for any model if OpenAI client is available
+            provider = "openai"
         elif gemini_client is not None:
             provider = "gemini"
         elif anthropic_client is not None:
             provider = "anthropic"
-        elif openai_client is not None:
-            provider = "openai"
         else:
             raise RuntimeError(
                 "No API client available. Please configure at least one API key "


### PR DESCRIPTION
1. Configurable Retry Count (text_model_max_attempts)
Replace the hardcoded max_attempts=5 with a configurable parameter across all Agents:
Files to modify:
critic_agent.py, planner_agent.py, retriever_agent.py, stylist_agent.py, visualizer_agent.py
Function: Allow users to control the maximum number of retries for failed API calls via configuration.
Default value: 5
2. Limit the Number of Reference Examples (max_reference_examples)
Add this feature in planner_agent.py:
Function: Restrict the number of reference examples used to avoid overly long prompts.
Default value: 10 examples
Code:
python
运行
examples = examples[:max_reference_examples]
3. Configurable Image Generation Parameters
Add multiple configurable parameters in generation_utils.py:
image_model_max_attempts: Maximum retry count for image generation (default: 3)
image_model_retry_delay: Retry delay (default: 5 seconds)
image_model_timeout: API timeout (default: 300 seconds)
4. Demo Script Enhancement
Update demo.py with the following improvements:
Support reading all the above new parameters from a configuration file
Pass configuration parameters to each Agent
5. .gitignore Update
Add paperbanana-0.1.0 to the ignore list.