### PR TITLE
feat: add --image_gen_model_name CLI argument to main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -82,6 +82,12 @@ async def main():
         default="",
         help="main model name to use (default: "")",
     )
+    parser.add_argument(
+        "--image_gen_model_name",
+        type=str,
+        default="",
+        help="image generation model name to use (default: "")",
+    )
     args = parser.parse_args()
 
     exp_config = config.ExpConfig(
@@ -92,6 +98,7 @@ async def main():
         retrieval_setting=args.retrieval_setting,
         max_critic_rounds=args.max_critic_rounds,
         main_model_name=args.main_model_name,
+        image_gen_model_name=args.image_gen_model_name,
         work_dir=Path(__file__).parent,
     )
     


### PR DESCRIPTION
## Problem

`main.py` exposes `--main_model_name` via CLI but is missing `--image_gen_model_name`. The `ExpConfig` dataclass already supports both fields, and both `demo.py` (Streamlit UI) and `skill/run.py` already pass `image_gen_model_name` — only the CLI entry point in `main.py` was missed.

This means CLI users must configure the image generation model through `configs/model_config.yaml` or environment variables, while the text model can be set directly via `--main_model_name`.

## Change

- Added `parser.add_argument("--image_gen_model_name", ...)` in `main.py`
- Passed `args.image_gen_model_name` to `config.ExpConfig(...)`
- Style matches the existing `--main_model_name` argument exactly

## Testing

- `python3 -m py_compile main.py` — passed
- Verified `ExpConfig.__post_init__` fallback chain: CLI arg → YAML config → env var → hard default. An empty string (the default) correctly falls through to YAML/env/default, so existing behavior is preserved.