### PR TITLE
Fix Windows UnicodeDecodeError when loading YAML config

### DIFF
--- a/utils/generation_utils.py
+++ b/utils/generation_utils.py
@@ -41,7 +41,7 @@ from pathlib import Path
 config_path = Path(__file__).parent.parent / "configs" / "model_config.yaml"
 model_config = {}
 if config_path.exists():
-    with open(config_path, "r") as f:
+    with open(config_path, "r", encoding="utf-8-sig") as f:
         model_config = yaml.safe_load(f) or {}
 
 def get_config_val(section, key, env_var, default=""):


### PR DESCRIPTION
## Summary

This PR fixes a Windows-specific `UnicodeDecodeError` when loading the YAML config file in `utils/generation_utils.py`.

The current code opens the config file using the platform default text encoding:

```python
with open(config_path, "r") as f:
    model_config = yaml.safe_load(f) or {}
````

On Windows, the default encoding may be `gbk` / `cp936`, which can fail when the config template contains UTF-8 characters.

This change makes config loading explicit and cross-platform safe by using:

```python
with open(config_path, "r", encoding="utf-8-sig") as f:
    model_config = yaml.safe_load(f) or {}
```

`utf-8-sig` is used here so the loader works with both standard UTF-8 files and UTF-8 files that include a BOM.

## Problem

On Windows, starting the Streamlit demo failed during import with:

```text
UnicodeDecodeError: 'gbk' codec can't decode byte 0x94 in position 675: illegal multibyte sequence
```

The traceback points to:

```text
File "E:\\PythonProjects\\PaperBanana\\utils\\generation_utils.py", line 45, in <module>
    model_config = yaml.safe_load(f) or {}
```

because the YAML config file was opened without an explicit encoding.

## Root cause

The code currently relies on the platform default encoding when reading the YAML config file.

* On many Linux environments, the default encoding is UTF-8, so this often works.
* On Windows, especially in Chinese locale environments, the default encoding may be GBK/CP936.
* If the config template is UTF-8 encoded, opening it with the Windows default encoding can raise `UnicodeDecodeError`.

## Fix

Use an explicit UTF-8-based encoding when opening the YAML config file:

```python
with open(config_path, "r", encoding="utf-8-sig") as f:
    model_config = yaml.safe_load(f) or {}
```

This makes config loading consistent across Windows and Linux, while also handling UTF-8 files with BOM.

## Reproduction

Environment:

* Windows
* PowerShell
* Streamlit app startup via `streamlit run demo.py`

Observed error:

```text
DEBUG: Exception during import: 'gbk' codec can't decode byte 0x94 in position 675: illegal multibyte sequence
...
File "E:\\PythonProjects\\PaperBanana\\utils\\generation_utils.py", line 45, in <module>
    model_config = yaml.safe_load(f) or {}
...
UnicodeDecodeError: 'gbk' codec can't decode byte 0x94 in position 675: illegal multibyte sequence
```

## Why `utf-8-sig`

This file is a user-editable config/template input rather than an internally generated file.
Using `utf-8-sig` for reading is a small compatibility improvement because it supports both:

* regular UTF-8 files
* UTF-8 files saved with BOM by some Windows editors/tools

## Notes

This is a minimal and backward-compatible change that avoids platform-dependent behavior when loading config files.
