### PR TITLE
feat: Gradio UI enhancements + multi-provider support + progress tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,13 @@
 configs/model_config.yaml
 __pycache__/
 *.pyc
-*.pyc
-__pycache__/
 .venv/
 data/
 results/
+
+# Secrets / environment files
+.env
+.env.*
+*.env
+configs/*.local.yaml
+configs/secrets*.yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,9 +3,7 @@
 ## Quick Start
 
 ```bash
-cd /Users/noking/claude\ pr/DJ/paper_banana
-source .venv/bin/activate
-cd PaperBanana
+source ../.venv/bin/activate   # venv is one level above repo
 python app.py                  # Gradio UI at http://localhost:7860
 python main.py                 # CLI mode
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,94 @@
+# CLAUDE.md
+
+## Quick Start
+
+```bash
+cd /Users/noking/claude\ pr/DJ/paper_banana
+source .venv/bin/activate
+cd PaperBanana
+python app.py                  # Gradio UI at http://localhost:7860
+streamlit run demo.py          # Legacy Streamlit UI at http://localhost:8501
+python main.py                 # CLI mode
+```
+
+## Project Structure
+
+```
+paper_banana/
+├── .venv/                     ← Shared venv (Python 3.14, one level above repo)
+├── PaperBanana/               ← Main repo (dev-gradio branch)
+│   ├── app.py                 ← Gradio web UI (primary)
+│   ├── demo.py                ← Streamlit web UI (legacy)
+│   ├── main.py                ← CLI entry point
+│   ├── agents/                ← 7 agents: Retriever → Planner → Stylist → Visualizer → Critic → Polish + Vanilla
+│   ├── utils/
+│   │   ├── generation_utils.py  ← API calls (Gemini, OpenRouter, Proma, Local proxy)
+│   │   ├── paperviz_processor.py ← Pipeline orchestrator + ProgressTracker
+│   │   └── config.py           ← ExpConfig dataclass
+│   ├── configs/model_config.yaml ← API keys and default models
+│   └── scripts/fix_text.py     ← OCR text correction tool (macOS only)
+└── PaperBanana-main/          ← git worktree (official main branch)
+```
+
+## Proxy
+
+Google AI API requires HTTP proxy (TUN doesn't work for Python SDK).
+app.py and demo.py auto-set `HTTPS_PROXY=http://127.0.0.1:7890` if not already set.
+FlClash mixed-port: 7890.
+
+## API Providers (6 total)
+
+| Provider | Prefix | Auto-detect | Config key |
+|----------|--------|-------------|------------|
+| Gemini | (bare name) | Yes (2nd priority) | `google_api_key` |
+| OpenRouter | `openrouter/` | Yes (1st priority) | `openrouter_api_key` |
+| Anthropic | `claude-` | Yes | `anthropic_api_key` |
+| OpenAI | `gpt-`/`o1-`/`o3-`/`o4-` | Yes | `openai_api_key` |
+| Proma | `proma/` | No, prefix required | `proma_api_key` |
+| Local proxy | `local/` | No, prefix required | `local_api_key` |
+
+## Image Models
+
+| Display name | Actual model | Notes |
+|---|---|---|
+| 🍌2 (Nano Banana 2 / Flash) | gemini-3.1-flash-image-preview | Default, fastest |
+| 🍌Pro (Nano Banana Pro) | gemini-3-pro-image-preview | Best quality |
+| 🍌1 (Nano Banana 1) | gemini-2.5-flash-image | Legacy fallback |
+
+Image generation routing in VisualizerAgent: OpenRouter > Gemini direct. Does NOT go through the text model router.
+
+## Operations
+
+```bash
+# Start Gradio (recommended)
+cd PaperBanana && python app.py
+
+# Restart Gradio
+lsof -i :7860 | grep LISTEN | awk '{print $2}' | xargs kill; python app.py
+
+# Run OCR text correction (macOS only)
+python scripts/fix_text.py image.png
+python scripts/fix_text.py image.png --mask
+```
+
+## Key Features (dev-gradio branch)
+
+- **Preflight model check**: Tests image model before full pipeline, with 503 fallback chain
+- **ProgressTracker**: Real-time stage tracking across parallel candidates
+- **Mock mode**: Simulate pipeline with delays, no API calls (for UI testing)
+- **Font injection**: Chinese/English font constraints injected into Visualizer prompt
+- **ImageGenerationError**: Aborts early on 400 region block, prevents wasted API costs on Critic rounds
+- **Fallback chain**: gemini-3.1-flash → gemini-3-pro → gemini-2.5-flash on 503
+
+## Gotchas
+
+- **Venv location**: `../.venv/` (one level above PaperBanana/, shared across worktrees)
+- **No .venv inside PaperBanana/**: Deleted — was incomplete and caused confusion
+- **`asyncio.run()` breaks in Gradio sync handlers**: Use `_run_async()` helper (wraps `new_event_loop` + `run_until_complete` + `close`)
+- **`create_sample_inputs()` uses `copy.deepcopy()`**: Fixed shallow copy bug where `additional_info` was shared across candidates
+- **Gemini 503 under load**: Fallback chain handles this automatically
+- **Google AI API 400 through TUN**: Must use HTTP proxy, set `NO_PROXY=localhost,127.0.0.1`
+- **`figure_size` UI dropdown is dead code**: Upstream bug, see [dwzhu-pku/PaperBanana#54](https://github.com/dwzhu-pku/PaperBanana/issues/54)
+- **Gradio `visible=False` first-render bug**: Use `interactive=False` or `gr.Column(visible)` wrapper instead
+- **Preflight skips when OpenRouter configured**: OpenRouter takes priority for image gen in VisualizerAgent
+- **Refine tab**: Converts RGBA/LA/P images to RGB before JPEG serialization

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,88 +7,35 @@ cd /Users/noking/claude\ pr/DJ/paper_banana
 source .venv/bin/activate
 cd PaperBanana
 python app.py                  # Gradio UI at http://localhost:7860
-streamlit run demo.py          # Legacy Streamlit UI at http://localhost:8501
 python main.py                 # CLI mode
 ```
 
-## Project Structure
+## Structure
 
 ```
 paper_banana/
-├── .venv/                     ← Shared venv (Python 3.14, one level above repo)
+├── .venv/                     ← Shared venv (Python 3.14), one level above repo
 ├── PaperBanana/               ← Main repo (dev-gradio branch)
-│   ├── app.py                 ← Gradio web UI (primary)
-│   ├── demo.py                ← Streamlit web UI (legacy)
-│   ├── main.py                ← CLI entry point
+│   ├── app.py                 ← Gradio web UI (primary entry point)
+│   ├── demo.py                ← Legacy Streamlit UI
 │   ├── agents/                ← 7 agents: Retriever → Planner → Stylist → Visualizer → Critic → Polish + Vanilla
-│   ├── utils/
-│   │   ├── generation_utils.py  ← API calls (Gemini, OpenRouter, Proma, Local proxy)
-│   │   ├── paperviz_processor.py ← Pipeline orchestrator + ProgressTracker
-│   │   └── config.py           ← ExpConfig dataclass
-│   ├── configs/model_config.yaml ← API keys and default models
-│   └── scripts/fix_text.py     ← OCR text correction tool (macOS only)
-└── PaperBanana-main/          ← git worktree (official main branch)
+│   ├── utils/generation_utils.py ← 6 API providers + routing
+│   ├── utils/paperviz_processor.py ← Pipeline orchestrator
+│   ├── configs/model_config.yaml  ← API keys and defaults
+│   └── scripts/fix_text.py    ← OCR text correction (macOS only)
+└── PaperBanana-main/          ← git worktree (upstream main)
 ```
 
 ## Proxy
 
-Google AI API requires HTTP proxy (TUN doesn't work for Python SDK).
-app.py and demo.py auto-set `HTTPS_PROXY=http://127.0.0.1:7890` if not already set.
-FlClash mixed-port: 7890.
-
-## API Providers (6 total)
-
-| Provider | Prefix | Auto-detect | Config key |
-|----------|--------|-------------|------------|
-| Gemini | (bare name) | Yes (2nd priority) | `google_api_key` |
-| OpenRouter | `openrouter/` | Yes (1st priority) | `openrouter_api_key` |
-| Anthropic | `claude-` | Yes | `anthropic_api_key` |
-| OpenAI | `gpt-`/`o1-`/`o3-`/`o4-` | Yes | `openai_api_key` |
-| Proma | `proma/` | No, prefix required | `proma_api_key` |
-| Local proxy | `local/` | No, prefix required | `local_api_key` |
-
-## Image Models
-
-| Display name | Actual model | Notes |
-|---|---|---|
-| 🍌2 (Nano Banana 2 / Flash) | gemini-3.1-flash-image-preview | Default, fastest |
-| 🍌Pro (Nano Banana Pro) | gemini-3-pro-image-preview | Best quality |
-| 🍌1 (Nano Banana 1) | gemini-2.5-flash-image | Legacy fallback |
-
-Image generation routing in VisualizerAgent: OpenRouter > Gemini direct. Does NOT go through the text model router.
-
-## Operations
-
-```bash
-# Start Gradio (recommended)
-cd PaperBanana && python app.py
-
-# Restart Gradio
-lsof -i :7860 | grep LISTEN | awk '{print $2}' | xargs kill; python app.py
-
-# Run OCR text correction (macOS only)
-python scripts/fix_text.py image.png
-python scripts/fix_text.py image.png --mask
-```
-
-## Key Features (dev-gradio branch)
-
-- **Preflight model check**: Tests image model before full pipeline, with 503 fallback chain
-- **ProgressTracker**: Real-time stage tracking across parallel candidates
-- **Mock mode**: Simulate pipeline with delays, no API calls (for UI testing)
-- **Font injection**: Chinese/English font constraints injected into Visualizer prompt
-- **ImageGenerationError**: Aborts early on 400 region block, prevents wasted API costs on Critic rounds
-- **Fallback chain**: gemini-3.1-flash → gemini-3-pro → gemini-2.5-flash on 503
+Google AI API requires HTTP proxy (TUN doesn't work). Auto-configured in app.py.
+FlClash mixed-port: `HTTPS_PROXY=http://127.0.0.1:7890`, set `NO_PROXY=localhost,127.0.0.1`.
 
 ## Gotchas
 
-- **Venv location**: `../.venv/` (one level above PaperBanana/, shared across worktrees)
-- **No .venv inside PaperBanana/**: Deleted — was incomplete and caused confusion
-- **`asyncio.run()` breaks in Gradio sync handlers**: Use `_run_async()` helper (wraps `new_event_loop` + `run_until_complete` + `close`)
-- **`create_sample_inputs()` uses `copy.deepcopy()`**: Fixed shallow copy bug where `additional_info` was shared across candidates
-- **Gemini 503 under load**: Fallback chain handles this automatically
-- **Google AI API 400 through TUN**: Must use HTTP proxy, set `NO_PROXY=localhost,127.0.0.1`
-- **`figure_size` UI dropdown is dead code**: Upstream bug, see [dwzhu-pku/PaperBanana#54](https://github.com/dwzhu-pku/PaperBanana/issues/54)
-- **Gradio `visible=False` first-render bug**: Use `interactive=False` or `gr.Column(visible)` wrapper instead
-- **Preflight skips when OpenRouter configured**: OpenRouter takes priority for image gen in VisualizerAgent
-- **Refine tab**: Converts RGBA/LA/P images to RGB before JPEG serialization
+- **Venv is at `../.venv/`**, not inside PaperBanana/ — shared across worktrees
+- **`asyncio.run()` breaks in Gradio** — use `_run_async()` helper in app.py
+- **Image gen routing bypasses text router** — VisualizerAgent uses OpenRouter > Gemini directly, not `call_model_with_retry_async()`
+- **`figure_size` dropdown is dead code** — upstream bug [#54](https://github.com/dwzhu-pku/PaperBanana/issues/54)
+- **Gemini 503**: automatic fallback chain (flash → pro → legacy)
+- **Gemini 400 region block**: abort immediately, check proxy

--- a/agents/visualizer_agent.py
+++ b/agents/visualizer_agent.py
@@ -119,7 +119,8 @@ class VisualizerAgent(BaseAgent):
             if key in data and f"{key}_base64_jpg" not in data:
                 desc_keys_to_process.append(key)
         
-        for round_idx in range(3):
+        max_critic_rounds = data.get("max_critic_rounds", 3)
+        for round_idx in range(max_critic_rounds):
             key = f"target_{task_name}_critic_desc{round_idx}"
             if key in data and f"{key}_base64_jpg" not in data:
                 critic_suggestions_key = f"target_{task_name}_critic_suggestions{round_idx}"

--- a/agents/visualizer_agent.py
+++ b/agents/visualizer_agent.py
@@ -127,17 +127,18 @@ class VisualizerAgent(BaseAgent):
         for desc_key in desc_keys_to_process:
             prompt_text = cfg["prompt_template"].format(desc=data[desc_key])
 
-            # Inject font constraints if specified
-            additional = data.get("additional_info", {})
-            font_cn = additional.get("font_cn", "")
-            font_en = additional.get("font_en", "")
-            if font_cn or font_en:
-                font_parts = []
-                if font_cn:
-                    font_parts.append(f"all Chinese text must use the {font_cn} font")
-                if font_en:
-                    font_parts.append(f"all English text and numbers must use the {font_en} font")
-                prompt_text += "\nIMPORTANT: In the diagram, " + ", and ".join(font_parts) + "."
+            # Inject font constraints only for image/diagram generation (not code-gen plots)
+            if cfg["use_image_generation"]:
+                additional = data.get("additional_info", {})
+                font_cn = additional.get("font_cn", "")
+                font_en = additional.get("font_en", "")
+                if font_cn or font_en:
+                    font_parts = []
+                    if font_cn:
+                        font_parts.append(f"all Chinese text must use the {font_cn} font")
+                    if font_en:
+                        font_parts.append(f"all English text and numbers must use the {font_en} font")
+                    prompt_text += "\nIMPORTANT: In the diagram, " + ", and ".join(font_parts) + "."
 
             content_list = [{"type": "text", "text": prompt_text}]
             

--- a/agents/visualizer_agent.py
+++ b/agents/visualizer_agent.py
@@ -65,36 +65,24 @@ class VisualizerAgent(BaseAgent):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        
-        # Task-specific configurations
         if "plot" in self.exp_config.task_name:
             self.model_name = self.exp_config.main_model_name
             self.system_prompt = PLOT_VISUALIZER_AGENT_SYSTEM_PROMPT
             self.process_executor = ProcessPoolExecutor(max_workers=32)
             self.task_config = {
                 "task_name": "plot",
-                "use_image_generation": False,  # Use code generation instead
+                "use_image_generation": False,
                 "prompt_template": "Use python matplotlib to generate a statistical plot based on the following detailed description: {desc}\n Only provide the code without any explanations. Code:",
                 "max_output_tokens": 50000,
             }
-            # The code below is for applying image generation models to statistics plots:
-            # self.model_name = self.exp_config.image_gen_model_name
-            # self.system_prompt = """You are an expert statistical plot illustrator. Generate high-quality statistical plots based on user requests. Note that you should not use code, but directly generate the image."""
-            # self.process_executor = None
-            # self.task_config = {
-            #     "task_name": "plot",
-            #     "use_image_generation": True,  # Use direct image generation
-            #     "prompt_template": "Render an image based on the following description: {desc}\n Plot:",
-            #     "max_output_tokens": 50000,
-            # }
 
         else:
             self.model_name = self.exp_config.image_gen_model_name
             self.system_prompt = DIAGRAM_VISUALIZER_AGENT_SYSTEM_PROMPT
-            self.process_executor = None  # Not needed for diagrams
+            self.process_executor = None
             self.task_config = {
                 "task_name": "diagram",
-                "use_image_generation": True,  # Use direct image generation
+                "use_image_generation": True,
                 "prompt_template": "Render an image based on the following detailed description: {desc}\n Note that do not include figure titles in the image. Diagram: ",
                 "max_output_tokens": 50000,
             }
@@ -104,10 +92,7 @@ class VisualizerAgent(BaseAgent):
             self.process_executor.shutdown(wait=True)
 
     async def process(self, data: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Unified processing method that works for both diagram and plot tasks.
-        Uses task_config to determine task-specific parameters.
-        """
+        """Process descriptions into images (diagrams) or code (plots)."""
         cfg = self.task_config
         task_name = cfg["task_name"]
         
@@ -163,10 +148,7 @@ class VisualizerAgent(BaseAgent):
                 "max_output_tokens": cfg["max_output_tokens"],
             }
             
-            # Resolve aspect ratio for image generation
-            aspect_ratio = "1:1"
-            if "additional_info" in data and "rounded_ratio" in data["additional_info"]:
-                aspect_ratio = data["additional_info"]["rounded_ratio"]
+            aspect_ratio = data.get("additional_info", {}).get("rounded_ratio", "1:1")
 
             if cfg["use_image_generation"]:
                 if "gpt-image" in self.model_name:
@@ -184,7 +166,6 @@ class VisualizerAgent(BaseAgent):
                         retry_delay=30,
                     )
                 elif generation_utils.openrouter_client is not None:
-                    # OpenRouter image generation
                     image_config = {
                         "system_prompt": self.system_prompt,
                         "temperature": self.exp_config.temperature,
@@ -199,7 +180,6 @@ class VisualizerAgent(BaseAgent):
                         retry_delay=30,
                     )
                 else:
-                    # Gemini direct image generation
                     gen_config_args["response_modalities"] = ["IMAGE"]
                     gen_config_args["image_config"] = types.ImageConfig(
                         aspect_ratio=aspect_ratio,
@@ -213,7 +193,6 @@ class VisualizerAgent(BaseAgent):
                         retry_delay=30,
                     )
             else:
-                # Code generation for plots — use the unified router
                 response_list = await generation_utils.call_model_with_retry_async(
                     model_name=self.model_name,
                     contents=content_list,
@@ -225,9 +204,7 @@ class VisualizerAgent(BaseAgent):
             if not response_list or not response_list[0]:
                 continue
             
-            # Post-process based on task type
             if cfg["use_image_generation"]:
-                # Convert PNG to JPG
                 converted_jpg = await asyncio.to_thread(
                     image_utils.convert_png_b64_to_jpg_b64, response_list[0]
                 )
@@ -236,12 +213,7 @@ class VisualizerAgent(BaseAgent):
                 else:
                     print(f"⚠️  Skipping {desc_key}: image conversion failed")
             else:
-                # Plot: execute generated code
                 raw_code = response_list[0]
-                
-                if not hasattr(self, "process_executor") or self.process_executor is None:
-                    print("Warning: Creating temporary ProcessPoolExecutor. Initialize one in __init__ for better performance.")
-                    self.process_executor = ProcessPoolExecutor(max_workers=4)
                 
                 base64_jpg = await loop.run_in_executor(
                     self.process_executor, _execute_plot_code_worker, raw_code
@@ -257,8 +229,3 @@ class VisualizerAgent(BaseAgent):
 DIAGRAM_VISUALIZER_AGENT_SYSTEM_PROMPT = """You are an expert scientific diagram illustrator. Generate high-quality scientific diagrams based on user requests."""
 
 PLOT_VISUALIZER_AGENT_SYSTEM_PROMPT = """You are an expert statistical plot illustrator. Write code to generate high-quality statistical plots based on user requests."""
-
-
-# !!! Note: If using image generation models, use the following system prompt instead:
-
-# PLOT_VISUALIZER_AGENT_SYSTEM_PROMPT = """You are an expert statistical plot illustrator. Generate high-quality statistical plots based on user requests. Note that you should not use code, but directly generate the image."""

--- a/agents/visualizer_agent.py
+++ b/agents/visualizer_agent.py
@@ -140,6 +140,19 @@ class VisualizerAgent(BaseAgent):
         
         for desc_key in desc_keys_to_process:
             prompt_text = cfg["prompt_template"].format(desc=data[desc_key])
+
+            # Inject font constraints if specified
+            additional = data.get("additional_info", {})
+            font_cn = additional.get("font_cn", "")
+            font_en = additional.get("font_en", "")
+            if font_cn or font_en:
+                font_parts = []
+                if font_cn:
+                    font_parts.append(f"all Chinese text must use the {font_cn} font")
+                if font_en:
+                    font_parts.append(f"all English text and numbers must use the {font_en} font")
+                prompt_text += "\nIMPORTANT: In the diagram, " + ", and ".join(font_parts) + "."
+
             content_list = [{"type": "text", "text": prompt_text}]
             
             gen_config_args = {

--- a/agents/visualizer_agent.py
+++ b/agents/visualizer_agent.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Vanilla Agent - Directly rendering images based on the method section.
+Visualizer Agent - Renders images from descriptions via image generation models.
 """
 
 from concurrent.futures import ProcessPoolExecutor

--- a/app.py
+++ b/app.py
@@ -179,20 +179,15 @@ async def preflight_check_image_model(image_gen_model_name: str) -> str:
         return _preflight_cache[image_gen_model_name]
     from utils.generation_utils import (
         ImageGenerationError, _get_fallback_model, _IMAGE_MODEL_FALLBACK_CHAIN,
-        fallback_events,
+        fallback_events, gemini_client, openrouter_client,
     )
-    from google import genai
     from google.genai import types
-
-    google_api_key = get_config_val("api_keys", "google_api_key", "GOOGLE_API_KEY", "")
-    if not google_api_key:
-        # No Google key but might use OpenRouter for images — skip preflight
-        from utils.generation_utils import openrouter_client
+    if gemini_client is None:
         if openrouter_client is not None:
             return image_gen_model_name
         raise ImageGenerationError("No Google API key configured and no OpenRouter available.")
 
-    client = genai.Client(api_key=google_api_key)
+    client = gemini_client
     model = image_gen_model_name
 
     while True:

--- a/app.py
+++ b/app.py
@@ -125,7 +125,7 @@ def create_sample_inputs(method_content, caption, aspect_ratio="16:9", num_copie
 
 async def process_parallel_candidates(
     data_list, exp_mode="dev_planner_critic", retrieval_setting="auto",
-    main_model_name="", image_gen_model_name="",
+    main_model_name="", image_gen_model_name="", progress_callback=None,
 ):
     exp_config = config.ExpConfig(
         dataset_name="Demo",
@@ -147,9 +147,124 @@ async def process_parallel_candidates(
         polish_agent=PolishAgent(exp_config=exp_config),
     )
     results = []
-    async for result_data in processor.process_queries_batch(data_list, max_concurrent=10, do_eval=False):
+    async for result_data in processor.process_queries_batch(
+        data_list, max_concurrent=10, do_eval=False,
+        progress_callback=progress_callback,
+    ):
         results.append(result_data)
     return results
+
+
+# ---------------------------------------------------------------------------
+# Preflight image model check with caching
+# ---------------------------------------------------------------------------
+_preflight_cache: dict = {}
+
+
+async def preflight_check_image_model(image_gen_model_name: str) -> str:
+    """Test image model before running the full pipeline. Returns the working model name."""
+    if image_gen_model_name in _preflight_cache:
+        return _preflight_cache[image_gen_model_name]
+    from utils.generation_utils import (
+        ImageGenerationError, _get_fallback_model, _IMAGE_MODEL_FALLBACK_CHAIN,
+        fallback_events,
+    )
+    from google import genai
+    from google.genai import types
+
+    google_api_key = get_config_val("api_keys", "google_api_key", "GOOGLE_API_KEY", "")
+    if not google_api_key:
+        raise ImageGenerationError("No Google API key configured.")
+
+    client = genai.Client(api_key=google_api_key)
+    model = image_gen_model_name
+
+    while True:
+        try:
+            response = await asyncio.to_thread(
+                client.models.generate_content,
+                model=model,
+                contents="Draw a small blue dot on white background",
+                config=types.GenerateContentConfig(
+                    response_modalities=["IMAGE"],
+                    image_config=types.ImageConfig(aspect_ratio="1:1", image_size="1k"),
+                ),
+            )
+            if response.candidates and response.candidates[0].content.parts:
+                for part in response.candidates[0].content.parts:
+                    if part.inline_data:
+                        _preflight_cache[image_gen_model_name] = model
+                        return model
+            raise Exception("Empty response from image model")
+
+        except Exception as e:
+            error_str = str(e)
+            error_lower = error_str.lower()
+            is_region = "400" in error_str and "location" in error_lower
+            is_overload = "503" in error_str or "unavailable" in error_lower
+
+            if is_region:
+                raise ImageGenerationError(
+                    f"❌ Model {model} blocked by region restriction (400). "
+                    f"Please check your proxy/VPN configuration."
+                )
+            if is_overload:
+                fallback = _get_fallback_model(model)
+                if fallback and fallback != model:
+                    fallback_events.append({
+                        "from": model, "to": fallback, "reason": "overloaded (503) in preflight",
+                    })
+                    model = fallback
+                    continue
+                else:
+                    raise ImageGenerationError(
+                        f"❌ All image models overloaded (503). Checked: {', '.join(_IMAGE_MODEL_FALLBACK_CHAIN)}"
+                    )
+            raise ImageGenerationError(f"❌ Image model preflight failed: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Mock pipeline for testing without API calls
+# ---------------------------------------------------------------------------
+import random
+from utils.paperviz_processor import ProgressTracker, PaperVizProcessor as _PVP
+
+
+async def mock_process_parallel_candidates(data_list, exp_mode="dev_planner_critic", delay_per_stage=2.0, progress_callback=None):
+    """Mock pipeline that simulates stages with delays. No API calls."""
+    max_critic_rounds = data_list[0].get("max_critic_rounds", 3) if data_list else 3
+    stages = _PVP._get_pipeline_stages(exp_mode, max_critic_rounds)
+    tracker = ProgressTracker(len(data_list), stages, callback=progress_callback) if progress_callback else None
+
+    # Simulate Retriever (serial)
+    if tracker:
+        tracker.enter_stage(-1, "Retriever", "mock/text-model")
+    await asyncio.sleep(delay_per_stage * 0.5)
+    if tracker:
+        for cid in range(len(data_list)):
+            tracker.complete_stage(cid, "Retriever")
+
+    candidate_stages = [s for s in stages if s != "Retriever"]
+
+    async def run_candidate(cid, data):
+        for stage in candidate_stages:
+            model = "mock/image-model" if "Visualizer" in stage else "mock/text-model"
+            if tracker:
+                tracker.enter_stage(cid, stage, model)
+            await asyncio.sleep(delay_per_stage * (0.5 + random.random()))
+            if "Critic" in stage and random.random() < 0.3:
+                if tracker:
+                    tracker.complete_stage(cid, stage)
+                break
+            if tracker:
+                tracker.complete_stage(cid, stage)
+        data["target_diagram_desc0"] = "Mock description for testing"
+        data["target_diagram_desc0_base64_jpg"] = ""
+        return data
+
+    tasks = [asyncio.create_task(run_candidate(i, d)) for i, d in enumerate(data_list)]
+    results = await asyncio.gather(*tasks)
+    return list(results)
 
 
 async def refine_image_with_nanoviz(image_bytes, edit_prompt, aspect_ratio="21:9", image_size="2K"):
@@ -617,6 +732,21 @@ def build_app():
                             value="Arial",
                             info="Font for English text and numbers",
                         )
+                        mock_mode = gr.Checkbox(
+                            label="Mock Mode (no API calls)",
+                            value=False,
+                            info="Test UI with simulated delays",
+                        )
+                        mock_delay = gr.Slider(
+                            minimum=0.5, maximum=10, value=2, step=0.5,
+                            label="Mock Delay (seconds/stage)",
+                            visible=False,
+                        )
+                        mock_mode.change(
+                            lambda v: gr.update(visible=v),
+                            inputs=[mock_mode],
+                            outputs=[mock_delay],
+                        )
                         save_results = gr.Dropdown(
                             choices=["Yes", "No"],
                             value="Yes",
@@ -683,7 +813,7 @@ def build_app():
                 def run_generate(
                     method_text, caption_text, pipe_mode, ret_setting,
                     n_cands, ar, max_rounds, m_model, img_model,
-                    f_cn, f_en, figure_size, save_results,
+                    f_cn, f_en, is_mock, m_delay, figure_size, save_results,
                     progress=gr.Progress(track_tqdm=True),
                 ):
                     if not method_text or not caption_text:
@@ -693,26 +823,69 @@ def build_app():
                     max_rounds = int(max_rounds)
                     timestamp_str = datetime.now().strftime("%Y%m%d_%H%M%S")
 
+                    # --- Progress callback that feeds Gradio progress bar ---
+                    def _progress_cb(status):
+                        pct = status.get("overall_pct", 0)
+                        stage = status.get("stage", "")
+                        model = status.get("model", "")
+                        done = status.get("stage_done", 0)
+                        total = status.get("total", 0)
+                        desc = f"{stage} ({done}/{total})"
+                        if model:
+                            desc += f" [{model}]"
+                        progress(min(0.1 + pct * 0.8, 0.9), desc=desc)
+
                     progress(0, desc="Preparing inputs...")
                     input_data = create_sample_inputs(
                         method_content=method_text, caption=caption_text,
                         aspect_ratio=ar, num_copies=n_cands, max_critic_rounds=max_rounds,
                         font_cn=f_cn, font_en=f_en,
                     )
-                    params = {"figure_size": figure_size}
 
-                    progress(0.1, desc=f"Generating {n_cands} candidates in parallel...")
-                    try:
-                        loop = asyncio.new_event_loop()
-                        results = loop.run_until_complete(
-                            process_parallel_candidates(
-                                input_data, exp_mode=pipe_mode, retrieval_setting=ret_setting,
-                                main_model_name=m_model, image_gen_model_name=img_model,
+                    if is_mock:
+                        # --- Mock mode: no API calls ---
+                        progress(0.05, desc="Mock mode: simulating pipeline...")
+                        try:
+                            loop = asyncio.new_event_loop()
+                            results = loop.run_until_complete(
+                                mock_process_parallel_candidates(
+                                    input_data, exp_mode=pipe_mode,
+                                    delay_per_stage=float(m_delay),
+                                    progress_callback=_progress_cb,
+                                )
                             )
-                        )
-                        loop.close()
-                    except Exception as e:
-                        raise gr.Error(f"Generation failed: {e}")
+                            loop.close()
+                        except Exception as e:
+                            raise gr.Error(f"Mock generation failed: {e}")
+                    else:
+                        # --- Real pipeline ---
+                        # Preflight check for image model
+                        progress(0.02, desc="Preflight: checking image model...")
+                        try:
+                            loop = asyncio.new_event_loop()
+                            verified_model = loop.run_until_complete(
+                                preflight_check_image_model(img_model)
+                            )
+                            loop.close()
+                            if verified_model != img_model:
+                                progress(0.05, desc=f"Fallback: using {verified_model}")
+                                img_model = verified_model
+                        except Exception as e:
+                            raise gr.Error(f"Image model preflight failed: {e}")
+
+                        progress(0.1, desc=f"Generating {n_cands} candidates in parallel...")
+                        try:
+                            loop = asyncio.new_event_loop()
+                            results = loop.run_until_complete(
+                                process_parallel_candidates(
+                                    input_data, exp_mode=pipe_mode, retrieval_setting=ret_setting,
+                                    main_model_name=m_model, image_gen_model_name=img_model,
+                                    progress_callback=_progress_cb,
+                                )
+                            )
+                            loop.close()
+                        except Exception as e:
+                            raise gr.Error(f"Generation failed: {e}")
 
                     progress(0.9, desc="Saving results...")
 
@@ -786,7 +959,7 @@ def build_app():
                         method_content, caption_input, pipeline_mode, retrieval_setting,
                         num_candidates, aspect_ratio, max_critic_rounds,
                         main_model_name, image_model_name,
-                        font_cn, font_en, figure_size, save_results,
+                        font_cn, font_en, mock_mode, mock_delay, figure_size, save_results,
                     ],
                     outputs=[
                         results_gallery, evolution_html, zip_file_output, status_text,

--- a/app.py
+++ b/app.py
@@ -166,8 +166,15 @@ async def preflight_check_image_model(image_gen_model_name: str) -> str:
     returns the model name as-is since those paths have their own retry logic.
     """
     # Skip preflight for non-Gemini image models
-    if image_gen_model_name.startswith(("gpt-image", "openrouter/", "proma/", "local/")):
+    if image_gen_model_name.startswith(("gpt-image", "openrouter/")):
         return image_gen_model_name
+    # Reject text-only provider prefixes for image generation
+    if image_gen_model_name.startswith(("proma/", "local/")):
+        from utils.generation_utils import ImageGenerationError
+        raise ImageGenerationError(
+            f"Image model '{image_gen_model_name}' uses a text-only provider prefix. "
+            f"Image generation only supports Gemini or OpenRouter models."
+        )
 
     # If OpenRouter is configured, it takes priority for image generation
     # in VisualizerAgent, so Gemini preflight is irrelevant
@@ -258,7 +265,7 @@ async def mock_process_parallel_candidates(data_list, exp_mode="dev_planner_crit
 
     # Simulate Retriever (serial)
     if tracker:
-        tracker.enter_stage(-1, "Retriever", "mock/text-model")
+        tracker.enter_stage(0, "Retriever", "mock/text-model")
     await asyncio.sleep(delay_per_stage * 0.5)
     if tracker:
         for cid in range(len(data_list)):

--- a/app.py
+++ b/app.py
@@ -800,15 +800,38 @@ def build_app():
                             inputs=[image_model_dropdown],
                             outputs=[image_model_name],
                         )
-                        font_cn = gr.Textbox(
-                            label="Chinese Font",
+                        font_cn = gr.Dropdown(
+                            choices=[
+                                "思源黑体",        # Source Han Sans — 清晰现代，学术首选
+                                "思源宋体",        # Source Han Serif — 正式严谨
+                                "微软雅黑",        # Microsoft YaHei — Windows 标配
+                                "PingFang SC",    # 苹方 — macOS/iOS 原生
+                                "Noto Sans SC",   # Google Noto — 跨平台一致
+                                "HarmonyOS Sans SC",  # 华为鸿蒙字体
+                                "阿里巴巴普惠体",   # Alibaba PuHuiTi — 免费商用
+                                "Custom",
+                            ],
                             value="思源黑体",
+                            label="Chinese Font",
                             info="Font for Chinese text in diagrams",
+                            allow_custom_value=True,
                         )
-                        font_en = gr.Textbox(
-                            label="English Font",
+                        font_en = gr.Dropdown(
+                            choices=[
+                                "Arial",           # 经典无衬线，渲染清晰
+                                "Helvetica",       # 设计界标杆
+                                "Roboto",          # Google 主力字体
+                                "Inter",           # 现代 UI 字体，数字等宽
+                                "SF Pro",          # Apple 系统字体
+                                "Times New Roman", # 学术论文经典衬线
+                                "Georgia",         # 屏幕友好衬线体
+                                "Fira Sans",       # Mozilla 出品，技术文档常用
+                                "Custom",
+                            ],
                             value="Arial",
+                            label="English Font",
                             info="Font for English text and numbers",
+                            allow_custom_value=True,
                         )
                         mock_mode = gr.Checkbox(
                             label="Mock Mode (no API calls)",

--- a/app.py
+++ b/app.py
@@ -802,38 +802,54 @@ def build_app():
                             inputs=[image_model_dropdown],
                             outputs=[image_model_name],
                         )
-                        font_cn = gr.Dropdown(
-                            choices=[
-                                "思源黑体",        # Source Han Sans — 清晰现代，学术首选
-                                "思源宋体",        # Source Han Serif — 正式严谨
-                                "微软雅黑",        # Microsoft YaHei — Windows 标配
-                                "PingFang SC",    # 苹方 — macOS/iOS 原生
-                                "Noto Sans SC",   # Google Noto — 跨平台一致
-                                "HarmonyOS Sans SC",  # 华为鸿蒙字体
-                                "阿里巴巴普惠体",   # Alibaba PuHuiTi — 免费商用
-                                "Custom",
-                            ],
+                        _CN_FONT_CHOICES = [
+                            "思源黑体", "思源宋体", "微软雅黑", "PingFang SC",
+                            "Noto Sans SC", "HarmonyOS Sans SC", "阿里巴巴普惠体", "Custom",
+                        ]
+                        _EN_FONT_CHOICES = [
+                            "Arial", "Helvetica", "Roboto", "Inter", "SF Pro",
+                            "Times New Roman", "Georgia", "Fira Sans", "Custom",
+                        ]
+                        font_cn_dropdown = gr.Dropdown(
+                            choices=_CN_FONT_CHOICES,
                             value="思源黑体",
                             label="Chinese Font",
                             info="Font for Chinese text in diagrams",
-                            allow_custom_value=True,
                         )
-                        font_en = gr.Dropdown(
-                            choices=[
-                                "Arial",           # 经典无衬线，渲染清晰
-                                "Helvetica",       # 设计界标杆
-                                "Roboto",          # Google 主力字体
-                                "Inter",           # 现代 UI 字体，数字等宽
-                                "SF Pro",          # Apple 系统字体
-                                "Times New Roman", # 学术论文经典衬线
-                                "Georgia",         # 屏幕友好衬线体
-                                "Fira Sans",       # Mozilla 出品，技术文档常用
-                                "Custom",
-                            ],
+                        font_cn = gr.Textbox(
+                            label="Custom Chinese Font",
+                            value="思源黑体",
+                            interactive=False,
+                        )
+                        def _on_font_cn_select(choice):
+                            if choice == "Custom":
+                                return gr.update(interactive=True, value="")
+                            return gr.update(interactive=False, value=choice)
+                        font_cn_dropdown.change(
+                            _on_font_cn_select,
+                            inputs=[font_cn_dropdown],
+                            outputs=[font_cn],
+                        )
+
+                        font_en_dropdown = gr.Dropdown(
+                            choices=_EN_FONT_CHOICES,
                             value="Arial",
                             label="English Font",
                             info="Font for English text and numbers",
-                            allow_custom_value=True,
+                        )
+                        font_en = gr.Textbox(
+                            label="Custom English Font",
+                            value="Arial",
+                            interactive=False,
+                        )
+                        def _on_font_en_select(choice):
+                            if choice == "Custom":
+                                return gr.update(interactive=True, value="")
+                            return gr.update(interactive=False, value=choice)
+                        font_en_dropdown.change(
+                            _on_font_en_select,
+                            inputs=[font_en_dropdown],
+                            outputs=[font_en],
                         )
                         mock_mode = gr.Checkbox(
                             label="Mock Mode (no API calls)",

--- a/app.py
+++ b/app.py
@@ -242,6 +242,15 @@ import random
 from utils.paperviz_processor import ProgressTracker, PaperVizProcessor as _PVP
 
 
+def _run_async(coro):
+    """Run an async coroutine in a fresh event loop."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
 async def mock_process_parallel_candidates(data_list, exp_mode="dev_planner_critic", delay_per_stage=2.0, progress_callback=None):
     """Mock pipeline that simulates stages with delays. No API calls."""
     max_critic_rounds = data_list[0].get("max_critic_rounds", 3) if data_list else 3
@@ -591,7 +600,6 @@ def build_app():
         gen_results_state = gr.State([])
         gen_mode_state = gr.State("demo_planner_critic")
         gen_timestamp_state = gr.State("")
-        gen_json_path_state = gr.State("")
 
         # ================================================================
         # HEADER
@@ -888,7 +896,6 @@ def build_app():
                     max_rounds = int(max_rounds)
                     timestamp_str = datetime.now().strftime("%Y%m%d_%H%M%S")
 
-                    # --- Progress callback that feeds Gradio progress bar ---
                     def _progress_cb(status):
                         pct = status.get("overall_pct", 0)
                         stage = status.get("stage", "")
@@ -907,53 +914,31 @@ def build_app():
                         font_cn=f_cn, font_en=f_en,
                     )
 
-                    if is_mock:
-                        # --- Mock mode: no API calls ---
-                        progress(0.05, desc="Mock mode: simulating pipeline...")
-                        loop = asyncio.new_event_loop()
-                        try:
-                            results = loop.run_until_complete(
-                                mock_process_parallel_candidates(
-                                    input_data, exp_mode=pipe_mode,
-                                    delay_per_stage=float(m_delay),
-                                    progress_callback=_progress_cb,
-                                )
-                            )
-                        except Exception as e:
-                            raise gr.Error(f"Mock generation failed: {e}")
-                        finally:
-                            loop.close()
-                    else:
-                        # --- Real pipeline ---
-                        # Preflight check for image model
-                        progress(0.02, desc="Preflight: checking image model...")
-                        loop = asyncio.new_event_loop()
-                        try:
-                            verified_model = loop.run_until_complete(
-                                preflight_check_image_model(img_model)
-                            )
-                        except Exception as e:
-                            raise gr.Error(f"Image model preflight failed: {e}")
-                        finally:
-                            loop.close()
-                        if verified_model != img_model:
-                            progress(0.05, desc=f"Fallback: using {verified_model}")
-                            img_model = verified_model
+                    try:
+                        if is_mock:
+                            progress(0.05, desc="Mock mode: simulating pipeline...")
+                            results = _run_async(mock_process_parallel_candidates(
+                                input_data, exp_mode=pipe_mode,
+                                delay_per_stage=float(m_delay),
+                                progress_callback=_progress_cb,
+                            ))
+                        else:
+                            progress(0.02, desc="Preflight: checking image model...")
+                            verified_model = _run_async(preflight_check_image_model(img_model))
+                            if verified_model != img_model:
+                                progress(0.05, desc=f"Fallback: using {verified_model}")
+                                img_model = verified_model
 
-                        progress(0.1, desc=f"Generating {n_cands} candidates in parallel...")
-                        loop = asyncio.new_event_loop()
-                        try:
-                            results = loop.run_until_complete(
-                                process_parallel_candidates(
-                                    input_data, exp_mode=pipe_mode, retrieval_setting=ret_setting,
-                                    main_model_name=m_model, image_gen_model_name=img_model,
-                                    progress_callback=_progress_cb,
-                                )
-                            )
-                        except Exception as e:
-                            raise gr.Error(f"Generation failed: {e}")
-                        finally:
-                            loop.close()
+                            progress(0.1, desc=f"Generating {n_cands} candidates in parallel...")
+                            results = _run_async(process_parallel_candidates(
+                                input_data, exp_mode=pipe_mode, retrieval_setting=ret_setting,
+                                main_model_name=m_model, image_gen_model_name=img_model,
+                                progress_callback=_progress_cb,
+                            ))
+                    except gr.Error:
+                        raise
+                    except Exception as e:
+                        raise gr.Error(f"Generation failed: {e}")
 
                     progress(0.9, desc="Saving results...")
 
@@ -970,11 +955,11 @@ def build_app():
                         json_filename = None
 
                     # Build gallery images
-                    gallery_images = []
-                    for idx, res in enumerate(results):
-                        img, _ = get_final_image(res, pipe_mode)
-                        if img:
-                            gallery_images.append((img, f"Candidate {idx}"))
+                    gallery_images = [
+                        (img, f"Candidate {idx}")
+                        for idx, res in enumerate(results)
+                        if (img := get_final_image(res, pipe_mode)[0])
+                    ]
 
                     # Build evolution HTML
                     evo_parts = []
@@ -1007,8 +992,8 @@ def build_app():
                             pass
 
                     status = f"Generated {len(results)} candidates at {datetime.now().strftime('%H:%M:%S')}."
-                    if json_filename and Path(str(json_filename)).exists():
-                        status += f" JSON saved to {Path(str(json_filename)).name}."
+                    if json_filename and json_filename.exists():
+                        status += f" JSON saved to {json_filename.name}."
 
                     progress(1.0, desc="Done!")
                     return (
@@ -1072,15 +1057,9 @@ def build_app():
                     pil_img.save(buf, format="JPEG")
                     image_bytes = buf.getvalue()
 
-                    loop = asyncio.new_event_loop()
-                    try:
-                        refined_bytes, msg = loop.run_until_complete(
-                            refine_image_with_nanoviz(image_bytes, prompt, aspect_ratio=ar, image_size=resolution)
-                        )
-                    except Exception as e:
-                        raise gr.Error(f"Refinement error: {e}")
-                    finally:
-                        loop.close()
+                    refined_bytes, msg = _run_async(
+                        refine_image_with_nanoviz(image_bytes, prompt, aspect_ratio=ar, image_size=resolution)
+                    )
 
                     if not refined_bytes:
                         raise gr.Error(msg)

--- a/app.py
+++ b/app.py
@@ -675,7 +675,7 @@ def build_app():
                     else:
                         os.environ.pop(env_var, None)
                 from utils.generation_utils import reinitialize_clients
-                initialized = reinitialize_clients()
+                initialized = reinitialize_clients(env_only=True)
                 if initialized:
                     return f"Clients initialized: {', '.join(initialized)}."
                 return (

--- a/app.py
+++ b/app.py
@@ -663,14 +663,17 @@ def build_app():
             gr.Markdown("*Keys are used only for this session and never stored.*")
 
             def apply_keys(or_key, g_key, proma_key, local_key):
-                if or_key:
-                    os.environ["OPENROUTER_API_KEY"] = or_key
-                if g_key:
-                    os.environ["GOOGLE_API_KEY"] = g_key
-                if proma_key:
-                    os.environ["PROMA_API_KEY"] = proma_key
-                if local_key:
-                    os.environ["LOCAL_API_KEY"] = local_key
+                # Set or clear each key so users can remove providers
+                for env_var, val in [
+                    ("OPENROUTER_API_KEY", or_key),
+                    ("GOOGLE_API_KEY", g_key),
+                    ("PROMA_API_KEY", proma_key),
+                    ("LOCAL_API_KEY", local_key),
+                ]:
+                    if val:
+                        os.environ[env_var] = val
+                    else:
+                        os.environ.pop(env_var, None)
                 from utils.generation_utils import reinitialize_clients
                 initialized = reinitialize_clients()
                 if initialized:

--- a/app.py
+++ b/app.py
@@ -169,6 +169,12 @@ async def preflight_check_image_model(image_gen_model_name: str) -> str:
     if image_gen_model_name.startswith(("gpt-image", "openrouter/", "proma/", "local/")):
         return image_gen_model_name
 
+    # If OpenRouter is configured, it takes priority for image generation
+    # in VisualizerAgent, so Gemini preflight is irrelevant
+    from utils.generation_utils import openrouter_client
+    if openrouter_client is not None:
+        return image_gen_model_name
+
     if image_gen_model_name in _preflight_cache:
         return _preflight_cache[image_gen_model_name]
     from utils.generation_utils import (
@@ -237,7 +243,7 @@ async def preflight_check_image_model(image_gen_model_name: str) -> str:
 # Mock pipeline for testing without API calls
 # ---------------------------------------------------------------------------
 import random
-from utils.paperviz_processor import ProgressTracker, PaperVizProcessor as _PVP
+from utils.paperviz_processor import ProgressTracker
 
 
 def _run_async(coro):
@@ -252,7 +258,7 @@ def _run_async(coro):
 async def mock_process_parallel_candidates(data_list, exp_mode="dev_planner_critic", delay_per_stage=2.0, progress_callback=None):
     """Mock pipeline that simulates stages with delays. No API calls."""
     max_critic_rounds = data_list[0].get("max_critic_rounds", 3) if data_list else 3
-    stages = _PVP._get_pipeline_stages(exp_mode, max_critic_rounds)
+    stages = PaperVizProcessor._get_pipeline_stages(exp_mode, max_critic_rounds)
     tracker = ProgressTracker(len(data_list), stages, callback=progress_callback) if progress_callback else None
 
     # Simulate Retriever (serial)
@@ -371,7 +377,7 @@ def get_evolution_stages(result, exp_mode):
         if k in result and result[k]:
             stages.append({"name": "Stylist", "image_key": k, "desc_key": f"target_{task_name}_stylist_desc0", "description": "Stylistically refined"})
     # Critic rounds
-    for r in range(4):
+    for r in range(10):  # support up to 10 critic rounds dynamically
         k = f"target_{task_name}_critic_desc{r}_base64_jpg"
         if k in result and result[k]:
             stages.append({
@@ -389,7 +395,7 @@ def get_final_image(result, exp_mode):
     task_name = "diagram"
     final_key = None
     final_desc_key = None
-    for r in range(3, -1, -1):
+    for r in range(9, -1, -1):  # match evolution stages range
         k = f"target_{task_name}_critic_desc{r}_base64_jpg"
         if k in result and result[k]:
             final_key = k
@@ -1047,6 +1053,8 @@ def build_app():
                         raise gr.Error("Please provide edit instructions.")
 
                     buf = BytesIO()
+                    if pil_img.mode in ("RGBA", "LA", "P"):
+                        pil_img = pil_img.convert("RGB")
                     pil_img.save(buf, format="JPEG")
                     image_bytes = buf.getvalue()
 

--- a/app.py
+++ b/app.py
@@ -763,16 +763,17 @@ def build_app():
                             label="Model Name",
                             info="Select a model or choose Custom to enter manually",
                         )
+                        _main_is_custom = default_main_model not in _TEXT_MODEL_CHOICES[:-1]
                         main_model_name = gr.Textbox(
                             label="Custom Model Name",
-                            value=default_main_model,
-                            visible=default_main_model not in _TEXT_MODEL_CHOICES[:-1],
+                            value=default_main_model if _main_is_custom else "",
+                            interactive=_main_is_custom,
                             info="Prefixes: local/, proma/, openrouter/",
                         )
                         def _on_main_model_select(choice):
                             if choice == "Custom":
-                                return gr.update(visible=True, value="")
-                            return gr.update(visible=False, value=choice)
+                                return gr.update(interactive=True, value="")
+                            return gr.update(interactive=False, value=choice)
                         main_model_dropdown.change(
                             _on_main_model_select,
                             inputs=[main_model_dropdown],
@@ -785,16 +786,17 @@ def build_app():
                             label="Image Generation Model",
                             info="Select an image model or choose Custom",
                         )
+                        _img_is_custom = default_image_model not in _IMAGE_MODEL_CHOICES[:-1]
                         image_model_name = gr.Textbox(
                             label="Custom Image Model",
-                            value=default_image_model,
-                            visible=default_image_model not in _IMAGE_MODEL_CHOICES[:-1],
+                            value=default_image_model if _img_is_custom else "",
+                            interactive=_img_is_custom,
                             info="Model for generating diagram images",
                         )
                         def _on_image_model_select(choice):
                             if choice == "Custom":
-                                return gr.update(visible=True, value="")
-                            return gr.update(visible=False, value=choice)
+                                return gr.update(interactive=True, value="")
+                            return gr.update(interactive=False, value=choice)
                         image_model_dropdown.change(
                             _on_image_model_select,
                             inputs=[image_model_dropdown],

--- a/app.py
+++ b/app.py
@@ -752,17 +752,30 @@ def build_app():
                             info="Select or type a custom model (prefixes: local/, proma/, openrouter/)",
                             allow_custom_value=True,
                         )
-                        image_model_name = gr.Dropdown(
-                            choices=[
-                                "gemini-3.1-flash-image-preview",
-                                "gemini-3-pro-image-preview",
-                                "gemini-2.5-flash-image",
-                                "gpt-image-1",
-                            ],
-                            value=default_image_model,
+                        _IMAGE_MODEL_MAP = {
+                            "🍌2 (Nano Banana 2 / Flash)": "gemini-3.1-flash-image-preview",
+                            "🍌Pro (Nano Banana Pro)": "gemini-3-pro-image-preview",
+                            "🍌1 (Nano Banana 1)": "gemini-2.5-flash-image",
+                        }
+                        _IMAGE_MODEL_DISPLAY = list(_IMAGE_MODEL_MAP.keys())
+                        _default_img_display = next(
+                            (k for k, v in _IMAGE_MODEL_MAP.items() if v == default_image_model),
+                            default_image_model,
+                        )
+                        image_model_dropdown = gr.Dropdown(
+                            choices=_IMAGE_MODEL_DISPLAY,
+                            value=_default_img_display,
                             label="Image Generation Model",
-                            info="Select or type a custom image model",
+                            info="Select or type a custom model name",
                             allow_custom_value=True,
+                        )
+                        image_model_name = gr.State(default_image_model)
+                        def _on_image_model_change(choice):
+                            return _IMAGE_MODEL_MAP.get(choice, choice)
+                        image_model_dropdown.change(
+                            _on_image_model_change,
+                            inputs=[image_model_dropdown],
+                            outputs=[image_model_name],
                         )
                         font_cn = gr.Dropdown(
                             choices=[

--- a/app.py
+++ b/app.py
@@ -759,49 +759,61 @@ def build_app():
                             "gpt-image-1",
                             "Custom",
                         ]
+                        _main_default_is_preset = default_main_model in _TEXT_MODEL_CHOICES[:-1]
                         main_model_dropdown = gr.Dropdown(
                             choices=_TEXT_MODEL_CHOICES,
-                            value=default_main_model if default_main_model in _TEXT_MODEL_CHOICES else "Custom",
+                            value=default_main_model if _main_default_is_preset else "Custom",
                             label="Model Name",
                             info="Select a model or choose Custom to enter manually",
                         )
-                        _main_is_custom = default_main_model not in _TEXT_MODEL_CHOICES[:-1]
-                        main_model_name = gr.Textbox(
-                            label="Custom Model Name",
-                            value=default_main_model if _main_is_custom else "",
-                            interactive=_main_is_custom,
-                            info="Prefixes: local/, proma/, openrouter/",
-                        )
+                        with gr.Column(visible=not _main_default_is_preset) as main_model_custom_col:
+                            main_model_custom = gr.Textbox(
+                                label="Custom Model Name",
+                                value="" if _main_default_is_preset else default_main_model,
+                                info="Prefixes: local/, proma/, openrouter/",
+                            )
+                        main_model_name = gr.State(default_main_model)
                         def _on_main_model_select(choice):
                             if choice == "Custom":
-                                return gr.update(interactive=True, value="")
-                            return gr.update(interactive=False, value=choice)
+                                return gr.update(visible=True), gr.update(value=""), ""
+                            return gr.update(visible=False), gr.update(value=choice), choice
                         main_model_dropdown.change(
                             _on_main_model_select,
                             inputs=[main_model_dropdown],
+                            outputs=[main_model_custom_col, main_model_custom, main_model_name],
+                        )
+                        main_model_custom.change(
+                            lambda v: v,
+                            inputs=[main_model_custom],
                             outputs=[main_model_name],
                         )
 
+                        _img_default_is_preset = default_image_model in _IMAGE_MODEL_CHOICES[:-1]
                         image_model_dropdown = gr.Dropdown(
                             choices=_IMAGE_MODEL_CHOICES,
-                            value=default_image_model if default_image_model in _IMAGE_MODEL_CHOICES else "Custom",
+                            value=default_image_model if _img_default_is_preset else "Custom",
                             label="Image Generation Model",
                             info="Select an image model or choose Custom",
                         )
-                        _img_is_custom = default_image_model not in _IMAGE_MODEL_CHOICES[:-1]
-                        image_model_name = gr.Textbox(
-                            label="Custom Image Model",
-                            value=default_image_model if _img_is_custom else "",
-                            interactive=_img_is_custom,
-                            info="Model for generating diagram images",
-                        )
+                        with gr.Column(visible=not _img_default_is_preset) as image_model_custom_col:
+                            image_model_custom = gr.Textbox(
+                                label="Custom Image Model",
+                                value="" if _img_default_is_preset else default_image_model,
+                                info="Model for generating diagram images",
+                            )
+                        image_model_name = gr.State(default_image_model)
                         def _on_image_model_select(choice):
                             if choice == "Custom":
-                                return gr.update(interactive=True, value="")
-                            return gr.update(interactive=False, value=choice)
+                                return gr.update(visible=True), gr.update(value=""), ""
+                            return gr.update(visible=False), gr.update(value=choice), choice
                         image_model_dropdown.change(
                             _on_image_model_select,
                             inputs=[image_model_dropdown],
+                            outputs=[image_model_custom_col, image_model_custom, image_model_name],
+                        )
+                        image_model_custom.change(
+                            lambda v: v,
+                            inputs=[image_model_custom],
                             outputs=[image_model_name],
                         )
                         _CN_FONT_CHOICES = [

--- a/app.py
+++ b/app.py
@@ -100,13 +100,18 @@ def base64_to_image(b64_str):
         return None
 
 
-def create_sample_inputs(method_content, caption, aspect_ratio="16:9", num_copies=10, max_critic_rounds=3):
+def create_sample_inputs(method_content, caption, aspect_ratio="16:9", num_copies=10, max_critic_rounds=3, font_cn="", font_en=""):
+    additional_info = {"rounded_ratio": aspect_ratio}
+    if font_cn:
+        additional_info["font_cn"] = font_cn
+    if font_en:
+        additional_info["font_en"] = font_en
     base_input = {
         "filename": "demo_input",
         "caption": caption,
         "content": method_content,
         "visual_intent": caption,
-        "additional_info": {"rounded_ratio": aspect_ratio},
+        "additional_info": additional_info,
         "max_critic_rounds": max_critic_rounds,
     }
     inputs = []
@@ -492,7 +497,8 @@ def build_app():
         with gr.Accordion("API Keys", open=False):
             gr.Markdown(
                 "**You do not need both keys.** Fill **at least one**: **OpenRouter** *or* **Google (Gemini)**. "
-                "If both are set, OpenRouter is preferred for automatic routing when available."
+                "If both are set, OpenRouter is preferred for automatic routing when available. "
+                "Proma and Local proxy require explicit model prefixes (`proma/`, `local/`)."
             )
             with gr.Row():
                 openrouter_key_input = gr.Textbox(
@@ -503,25 +509,38 @@ def build_app():
                     label="Google API Key (optional)", type="password", placeholder="AIza...",
                     value=get_config_val("api_keys", "google_api_key", "GOOGLE_API_KEY", ""),
                 )
+            with gr.Row():
+                proma_key_input = gr.Textbox(
+                    label="Proma API Key (optional)", type="password", placeholder="pk-...",
+                    value=get_config_val("api_keys", "proma_api_key", "PROMA_API_KEY", ""),
+                )
+                local_key_input = gr.Textbox(
+                    label="Local Proxy API Key (optional)", type="password", placeholder="sk-...",
+                    value=get_config_val("api_keys", "local_api_key", "LOCAL_API_KEY", ""),
+                )
             gr.Markdown("*Keys are used only for this session and never stored.*")
 
-            def apply_keys(or_key, g_key):
+            def apply_keys(or_key, g_key, proma_key, local_key):
                 if or_key:
                     os.environ["OPENROUTER_API_KEY"] = or_key
                 if g_key:
                     os.environ["GOOGLE_API_KEY"] = g_key
+                if proma_key:
+                    os.environ["PROMA_API_KEY"] = proma_key
+                if local_key:
+                    os.environ["LOCAL_API_KEY"] = local_key
                 from utils.generation_utils import reinitialize_clients
                 initialized = reinitialize_clients()
                 if initialized:
                     return f"Clients initialized: {', '.join(initialized)}."
                 return (
                     "Warning: no API clients could be initialized. "
-                    "Enter at least one key—OpenRouter or Google (Gemini)."
+                    "Enter at least one key."
                 )
 
             apply_keys_btn = gr.Button("Apply Keys", size="sm")
             keys_status = gr.Textbox(visible=False)
-            apply_keys_btn.click(apply_keys, inputs=[openrouter_key_input, google_key_input], outputs=[keys_status])
+            apply_keys_btn.click(apply_keys, inputs=[openrouter_key_input, google_key_input, proma_key_input, local_key_input], outputs=[keys_status])
 
         # ================================================================
         # TABS
@@ -580,13 +599,23 @@ def build_app():
                         )
                         main_model_name = gr.Textbox(
                             label="Model Name",
-                            info="Model name to use for reasoning",
+                            info="Prefixes: local/, proma/, openrouter/, or bare name for auto-detect",
                             value=default_main_model,
                         )
                         image_model_name = gr.Textbox(
                             label="Image Generation Model",
                             info="Model for generating diagram images",
                             value=default_image_model,
+                        )
+                        font_cn = gr.Textbox(
+                            label="Chinese Font",
+                            value="思源黑体",
+                            info="Font for Chinese text in diagrams",
+                        )
+                        font_en = gr.Textbox(
+                            label="English Font",
+                            value="Arial",
+                            info="Font for English text and numbers",
                         )
                         save_results = gr.Dropdown(
                             choices=["Yes", "No"],
@@ -654,7 +683,7 @@ def build_app():
                 def run_generate(
                     method_text, caption_text, pipe_mode, ret_setting,
                     n_cands, ar, max_rounds, m_model, img_model,
-                    figure_size, save_results,
+                    f_cn, f_en, figure_size, save_results,
                     progress=gr.Progress(track_tqdm=True),
                 ):
                     if not method_text or not caption_text:
@@ -668,6 +697,7 @@ def build_app():
                     input_data = create_sample_inputs(
                         method_content=method_text, caption=caption_text,
                         aspect_ratio=ar, num_copies=n_cands, max_critic_rounds=max_rounds,
+                        font_cn=f_cn, font_en=f_en,
                     )
                     params = {"figure_size": figure_size}
 
@@ -756,7 +786,7 @@ def build_app():
                         method_content, caption_input, pipeline_mode, retrieval_setting,
                         num_candidates, aspect_ratio, max_critic_rounds,
                         main_model_name, image_model_name,
-                        figure_size, save_results,
+                        font_cn, font_en, figure_size, save_results,
                     ],
                     outputs=[
                         results_gallery, evolution_html, zip_file_output, status_text,

--- a/app.py
+++ b/app.py
@@ -162,7 +162,15 @@ _preflight_cache: dict = {}
 
 
 async def preflight_check_image_model(image_gen_model_name: str) -> str:
-    """Test image model before running the full pipeline. Returns the working model name."""
+    """Test image model before running the full pipeline. Returns the working model name.
+
+    Only runs Gemini-specific preflight. For OpenRouter / gpt-image models,
+    returns the model name as-is since those paths have their own retry logic.
+    """
+    # Skip preflight for non-Gemini image models
+    if image_gen_model_name.startswith(("gpt-image", "openrouter/", "proma/", "local/")):
+        return image_gen_model_name
+
     if image_gen_model_name in _preflight_cache:
         return _preflight_cache[image_gen_model_name]
     from utils.generation_utils import (
@@ -174,7 +182,11 @@ async def preflight_check_image_model(image_gen_model_name: str) -> str:
 
     google_api_key = get_config_val("api_keys", "google_api_key", "GOOGLE_API_KEY", "")
     if not google_api_key:
-        raise ImageGenerationError("No Google API key configured.")
+        # No Google key but might use OpenRouter for images — skip preflight
+        from utils.generation_utils import openrouter_client
+        if openrouter_client is not None:
+            return image_gen_model_name
+        raise ImageGenerationError("No Google API key configured and no OpenRouter available.")
 
     client = genai.Client(api_key=google_api_key)
     model = image_gen_model_name
@@ -247,7 +259,8 @@ async def mock_process_parallel_candidates(data_list, exp_mode="dev_planner_crit
     candidate_stages = [s for s in stages if s != "Retriever"]
 
     async def run_candidate(cid, data):
-        for stage in candidate_stages:
+        stopped_at = len(candidate_stages)
+        for idx, stage in enumerate(candidate_stages):
             model = "mock/image-model" if "Visualizer" in stage else "mock/text-model"
             if tracker:
                 tracker.enter_stage(cid, stage, model)
@@ -255,9 +268,14 @@ async def mock_process_parallel_candidates(data_list, exp_mode="dev_planner_crit
             if "Critic" in stage and random.random() < 0.3:
                 if tracker:
                     tracker.complete_stage(cid, stage)
+                stopped_at = idx + 1
                 break
             if tracker:
                 tracker.complete_stage(cid, stage)
+        # Mark remaining skipped stages as complete (match real pipeline behavior)
+        if tracker:
+            for remaining_stage in candidate_stages[stopped_at:]:
+                tracker.complete_stage(cid, remaining_stage)
         data["target_diagram_desc0"] = "Mock description for testing"
         data["target_diagram_desc0_base64_jpg"] = ""
         return data
@@ -845,8 +863,8 @@ def build_app():
                     if is_mock:
                         # --- Mock mode: no API calls ---
                         progress(0.05, desc="Mock mode: simulating pipeline...")
+                        loop = asyncio.new_event_loop()
                         try:
-                            loop = asyncio.new_event_loop()
                             results = loop.run_until_complete(
                                 mock_process_parallel_candidates(
                                     input_data, exp_mode=pipe_mode,
@@ -854,28 +872,30 @@ def build_app():
                                     progress_callback=_progress_cb,
                                 )
                             )
-                            loop.close()
                         except Exception as e:
                             raise gr.Error(f"Mock generation failed: {e}")
+                        finally:
+                            loop.close()
                     else:
                         # --- Real pipeline ---
                         # Preflight check for image model
                         progress(0.02, desc="Preflight: checking image model...")
+                        loop = asyncio.new_event_loop()
                         try:
-                            loop = asyncio.new_event_loop()
                             verified_model = loop.run_until_complete(
                                 preflight_check_image_model(img_model)
                             )
-                            loop.close()
-                            if verified_model != img_model:
-                                progress(0.05, desc=f"Fallback: using {verified_model}")
-                                img_model = verified_model
                         except Exception as e:
                             raise gr.Error(f"Image model preflight failed: {e}")
+                        finally:
+                            loop.close()
+                        if verified_model != img_model:
+                            progress(0.05, desc=f"Fallback: using {verified_model}")
+                            img_model = verified_model
 
                         progress(0.1, desc=f"Generating {n_cands} candidates in parallel...")
+                        loop = asyncio.new_event_loop()
                         try:
-                            loop = asyncio.new_event_loop()
                             results = loop.run_until_complete(
                                 process_parallel_candidates(
                                     input_data, exp_mode=pipe_mode, retrieval_setting=ret_setting,
@@ -883,9 +903,10 @@ def build_app():
                                     progress_callback=_progress_cb,
                                 )
                             )
-                            loop.close()
                         except Exception as e:
                             raise gr.Error(f"Generation failed: {e}")
+                        finally:
+                            loop.close()
 
                     progress(0.9, desc="Saving results...")
 

--- a/app.py
+++ b/app.py
@@ -715,7 +715,7 @@ def build_app():
                             info="How to retrieve reference diagrams",
                         )
                         num_candidates = gr.Number(
-                            value=10, minimum=1, maximum=20, step=1,
+                            value=2, minimum=1, maximum=20, step=1,
                             label="Number of Candidates",
                         )
                         aspect_ratio = gr.Dropdown(

--- a/app.py
+++ b/app.py
@@ -841,10 +841,10 @@ def build_app():
                         mock_delay = gr.Slider(
                             minimum=0.5, maximum=10, value=2, step=0.5,
                             label="Mock Delay (seconds/stage)",
-                            visible=False,
+                            interactive=False,
                         )
                         mock_mode.change(
-                            lambda v: gr.update(visible=v),
+                            lambda v: gr.update(interactive=v),
                             inputs=[mock_mode],
                             outputs=[mock_delay],
                         )

--- a/app.py
+++ b/app.py
@@ -732,151 +732,57 @@ def build_app():
                             minimum=1, maximum=5, value=3, step=1,
                             label="Max Critic Rounds",
                         )
-                        _TEXT_MODEL_CHOICES = [
-                            # Gemini
-                            "gemini-3.1-pro-preview",
-                            "gemini-2.5-flash-preview-05-20",
-                            # Proma
-                            "proma/gemini-3.1-pro-preview",
-                            "proma/claude-sonnet-4-6",
-                            "proma/gpt-5-mini",
-                            "proma/deepseek-v3.2",
-                            # Proma Low-Cost
-                            "proma/lc-claude-opus-4-6",
-                            "proma/lc-claude-haiku-4-5-20251001",
-                            "proma/lc-kimi-k2.5",
-                            # Local
-                            "local/claude-opus-4-6",
-                            "local/claude-sonnet-4-6",
-                            "local/gpt-5.4",
-                            # Custom
-                            "Custom",
-                        ]
-                        _IMAGE_MODEL_CHOICES = [
-                            "gemini-3.1-flash-image-preview",
-                            "gemini-3-pro-image-preview",
-                            "gemini-2.5-flash-image",
-                            "gpt-image-1",
-                            "Custom",
-                        ]
-                        _main_default_is_preset = default_main_model in _TEXT_MODEL_CHOICES[:-1]
-                        main_model_dropdown = gr.Dropdown(
-                            choices=_TEXT_MODEL_CHOICES,
-                            value=default_main_model if _main_default_is_preset else "Custom",
+                        main_model_name = gr.Dropdown(
+                            choices=[
+                                "gemini-3.1-pro-preview",
+                                "gemini-2.5-flash-preview-05-20",
+                                "proma/gemini-3.1-pro-preview",
+                                "proma/claude-sonnet-4-6",
+                                "proma/gpt-5-mini",
+                                "proma/deepseek-v3.2",
+                                "proma/lc-claude-opus-4-6",
+                                "proma/lc-claude-haiku-4-5-20251001",
+                                "proma/lc-kimi-k2.5",
+                                "local/claude-opus-4-6",
+                                "local/claude-sonnet-4-6",
+                                "local/gpt-5.4",
+                            ],
+                            value=default_main_model,
                             label="Model Name",
-                            info="Select a model or choose Custom to enter manually",
+                            info="Select or type a custom model (prefixes: local/, proma/, openrouter/)",
+                            allow_custom_value=True,
                         )
-                        with gr.Column(visible=not _main_default_is_preset) as main_model_custom_col:
-                            main_model_custom = gr.Textbox(
-                                label="Custom Model Name",
-                                value="" if _main_default_is_preset else default_main_model,
-                                info="Prefixes: local/, proma/, openrouter/",
-                            )
-                        main_model_name = gr.State(default_main_model)
-                        def _on_main_model_select(choice):
-                            if choice == "Custom":
-                                return gr.update(visible=True), gr.update(value=""), ""
-                            return gr.update(visible=False), gr.update(value=choice), choice
-                        main_model_dropdown.change(
-                            _on_main_model_select,
-                            inputs=[main_model_dropdown],
-                            outputs=[main_model_custom_col, main_model_custom, main_model_name],
-                        )
-                        main_model_custom.change(
-                            lambda v: v,
-                            inputs=[main_model_custom],
-                            outputs=[main_model_name],
-                        )
-
-                        _img_default_is_preset = default_image_model in _IMAGE_MODEL_CHOICES[:-1]
-                        image_model_dropdown = gr.Dropdown(
-                            choices=_IMAGE_MODEL_CHOICES,
-                            value=default_image_model if _img_default_is_preset else "Custom",
+                        image_model_name = gr.Dropdown(
+                            choices=[
+                                "gemini-3.1-flash-image-preview",
+                                "gemini-3-pro-image-preview",
+                                "gemini-2.5-flash-image",
+                                "gpt-image-1",
+                            ],
+                            value=default_image_model,
                             label="Image Generation Model",
-                            info="Select an image model or choose Custom",
+                            info="Select or type a custom image model",
+                            allow_custom_value=True,
                         )
-                        with gr.Column(visible=not _img_default_is_preset) as image_model_custom_col:
-                            image_model_custom = gr.Textbox(
-                                label="Custom Image Model",
-                                value="" if _img_default_is_preset else default_image_model,
-                                info="Model for generating diagram images",
-                            )
-                        image_model_name = gr.State(default_image_model)
-                        def _on_image_model_select(choice):
-                            if choice == "Custom":
-                                return gr.update(visible=True), gr.update(value=""), ""
-                            return gr.update(visible=False), gr.update(value=choice), choice
-                        image_model_dropdown.change(
-                            _on_image_model_select,
-                            inputs=[image_model_dropdown],
-                            outputs=[image_model_custom_col, image_model_custom, image_model_name],
-                        )
-                        image_model_custom.change(
-                            lambda v: v,
-                            inputs=[image_model_custom],
-                            outputs=[image_model_name],
-                        )
-                        _CN_FONT_CHOICES = [
-                            "思源黑体", "思源宋体", "微软雅黑", "PingFang SC",
-                            "Noto Sans SC", "HarmonyOS Sans SC", "阿里巴巴普惠体", "Custom",
-                        ]
-                        _EN_FONT_CHOICES = [
-                            "Arial", "Helvetica", "Roboto", "Inter", "SF Pro",
-                            "Times New Roman", "Georgia", "Fira Sans", "Custom",
-                        ]
-                        font_cn_dropdown = gr.Dropdown(
-                            choices=_CN_FONT_CHOICES,
+                        font_cn = gr.Dropdown(
+                            choices=[
+                                "思源黑体", "思源宋体", "微软雅黑", "PingFang SC",
+                                "Noto Sans SC", "HarmonyOS Sans SC", "阿里巴巴普惠体",
+                            ],
                             value="思源黑体",
                             label="Chinese Font",
-                            info="Font for Chinese text in diagrams",
+                            info="Select or type a custom font name",
+                            allow_custom_value=True,
                         )
-                        with gr.Column(visible=False) as font_cn_custom_col:
-                            font_cn_custom = gr.Textbox(
-                                label="Custom Chinese Font",
-                                value="",
-                            )
-                        # Hidden state that always holds the effective font value
-                        font_cn = gr.State("思源黑体")
-                        def _on_font_cn_select(choice):
-                            if choice == "Custom":
-                                return gr.update(visible=True), gr.update(value=""), ""
-                            return gr.update(visible=False), gr.update(value=choice), choice
-                        font_cn_dropdown.change(
-                            _on_font_cn_select,
-                            inputs=[font_cn_dropdown],
-                            outputs=[font_cn_custom_col, font_cn_custom, font_cn],
-                        )
-                        font_cn_custom.change(
-                            lambda v: v,
-                            inputs=[font_cn_custom],
-                            outputs=[font_cn],
-                        )
-
-                        font_en_dropdown = gr.Dropdown(
-                            choices=_EN_FONT_CHOICES,
+                        font_en = gr.Dropdown(
+                            choices=[
+                                "Arial", "Helvetica", "Roboto", "Inter", "SF Pro",
+                                "Times New Roman", "Georgia", "Fira Sans",
+                            ],
                             value="Arial",
                             label="English Font",
-                            info="Font for English text and numbers",
-                        )
-                        with gr.Column(visible=False) as font_en_custom_col:
-                            font_en_custom = gr.Textbox(
-                                label="Custom English Font",
-                                value="",
-                            )
-                        font_en = gr.State("Arial")
-                        def _on_font_en_select(choice):
-                            if choice == "Custom":
-                                return gr.update(visible=True), gr.update(value=""), ""
-                            return gr.update(visible=False), gr.update(value=choice), choice
-                        font_en_dropdown.change(
-                            _on_font_en_select,
-                            inputs=[font_en_dropdown],
-                            outputs=[font_en_custom_col, font_en_custom, font_en],
-                        )
-                        font_en_custom.change(
-                            lambda v: v,
-                            inputs=[font_en_custom],
-                            outputs=[font_en],
+                            info="Select or type a custom font name",
+                            allow_custom_value=True,
                         )
                         mock_mode = gr.Checkbox(
                             label="Mock Mode (no API calls)",

--- a/app.py
+++ b/app.py
@@ -20,6 +20,7 @@ Replaces the Streamlit demo.py with a modern dark-themed interface.
 import gradio as gr
 import asyncio
 import base64
+import copy
 import json
 import zipfile
 from io import BytesIO
@@ -110,7 +111,7 @@ def create_sample_inputs(method_content, caption, aspect_ratio="16:9", num_copie
     }
     inputs = []
     for i in range(num_copies):
-        c = base_input.copy()
+        c = copy.deepcopy(base_input)
         c["filename"] = f"demo_input_candidate_{i}"
         c["candidate_id"] = i
         inputs.append(c)

--- a/app.py
+++ b/app.py
@@ -730,15 +730,75 @@ def build_app():
                             minimum=1, maximum=5, value=3, step=1,
                             label="Max Critic Rounds",
                         )
-                        main_model_name = gr.Textbox(
+                        _TEXT_MODEL_CHOICES = [
+                            # Gemini
+                            "gemini-3.1-pro-preview",
+                            "gemini-2.5-flash-preview-05-20",
+                            # Proma
+                            "proma/gemini-3.1-pro-preview",
+                            "proma/claude-sonnet-4-6",
+                            "proma/gpt-5-mini",
+                            "proma/deepseek-v3.2",
+                            # Proma Low-Cost
+                            "proma/lc-claude-opus-4-6",
+                            "proma/lc-claude-haiku-4-5-20251001",
+                            "proma/lc-kimi-k2.5",
+                            # Local
+                            "local/claude-opus-4-6",
+                            "local/claude-sonnet-4-6",
+                            "local/gpt-5.4",
+                            # Custom
+                            "Custom",
+                        ]
+                        _IMAGE_MODEL_CHOICES = [
+                            "gemini-3.1-flash-image-preview",
+                            "gemini-3-pro-image-preview",
+                            "gemini-2.5-flash-image",
+                            "gpt-image-1",
+                            "Custom",
+                        ]
+                        main_model_dropdown = gr.Dropdown(
+                            choices=_TEXT_MODEL_CHOICES,
+                            value=default_main_model if default_main_model in _TEXT_MODEL_CHOICES else "Custom",
                             label="Model Name",
-                            info="Prefixes: local/, proma/, openrouter/, or bare name for auto-detect",
+                            info="Select a model or choose Custom to enter manually",
+                        )
+                        main_model_name = gr.Textbox(
+                            label="Custom Model Name",
                             value=default_main_model,
+                            visible=default_main_model not in _TEXT_MODEL_CHOICES[:-1],
+                            info="Prefixes: local/, proma/, openrouter/",
+                        )
+                        def _on_main_model_select(choice):
+                            if choice == "Custom":
+                                return gr.update(visible=True, value="")
+                            return gr.update(visible=False, value=choice)
+                        main_model_dropdown.change(
+                            _on_main_model_select,
+                            inputs=[main_model_dropdown],
+                            outputs=[main_model_name],
+                        )
+
+                        image_model_dropdown = gr.Dropdown(
+                            choices=_IMAGE_MODEL_CHOICES,
+                            value=default_image_model if default_image_model in _IMAGE_MODEL_CHOICES else "Custom",
+                            label="Image Generation Model",
+                            info="Select an image model or choose Custom",
                         )
                         image_model_name = gr.Textbox(
-                            label="Image Generation Model",
-                            info="Model for generating diagram images",
+                            label="Custom Image Model",
                             value=default_image_model,
+                            visible=default_image_model not in _IMAGE_MODEL_CHOICES[:-1],
+                            info="Model for generating diagram images",
+                        )
+                        def _on_image_model_select(choice):
+                            if choice == "Custom":
+                                return gr.update(visible=True, value="")
+                            return gr.update(visible=False, value=choice)
+                        image_model_dropdown.change(
+                            _on_image_model_select,
+                            inputs=[image_model_dropdown],
+                            outputs=[image_model_name],
                         )
                         font_cn = gr.Textbox(
                             label="Chinese Font",

--- a/app.py
+++ b/app.py
@@ -82,8 +82,6 @@ def get_config_val(section, key, env_var, default=""):
 # ---------------------------------------------------------------------------
 
 def clean_text(text):
-    if not text:
-        return text
     if isinstance(text, str):
         return text.encode("utf-8", errors="ignore").decode("utf-8", errors="ignore")
     return text
@@ -243,7 +241,7 @@ from utils.paperviz_processor import ProgressTracker, PaperVizProcessor as _PVP
 
 
 def _run_async(coro):
-    """Run an async coroutine in a fresh event loop."""
+    """Run an async coroutine in a fresh event loop (needed inside Gradio sync handlers)."""
     loop = asyncio.new_event_loop()
     try:
         return loop.run_until_complete(coro)
@@ -298,14 +296,9 @@ async def refine_image_with_nanoviz(image_bytes, edit_prompt, aspect_ratio="21:9
     image_model = get_config_val("defaults", "image_gen_model_name", "IMAGE_GEN_MODEL_NAME", "")
     image_b64 = base64.b64encode(image_bytes).decode("utf-8")
 
-    # Path 1: OpenRouter
-    try:
-        from utils.generation_utils import call_openrouter_image_generation_with_retry_async
-        _has_openrouter = True
-    except ImportError:
-        _has_openrouter = False
+    from utils.generation_utils import call_openrouter_image_generation_with_retry_async
     openrouter_api_key = get_config_val("api_keys", "openrouter_api_key", "OPENROUTER_API_KEY", "")
-    if _has_openrouter and openrouter_api_key:
+    if openrouter_api_key:
         try:
             contents = [
                 {"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": image_b64}},

--- a/app.py
+++ b/app.py
@@ -818,18 +818,25 @@ def build_app():
                             label="Chinese Font",
                             info="Font for Chinese text in diagrams",
                         )
-                        font_cn = gr.Textbox(
-                            label="Custom Chinese Font",
-                            value="思源黑体",
-                            interactive=False,
-                        )
+                        with gr.Column(visible=False) as font_cn_custom_col:
+                            font_cn_custom = gr.Textbox(
+                                label="Custom Chinese Font",
+                                value="",
+                            )
+                        # Hidden state that always holds the effective font value
+                        font_cn = gr.State("思源黑体")
                         def _on_font_cn_select(choice):
                             if choice == "Custom":
-                                return gr.update(interactive=True, value="")
-                            return gr.update(interactive=False, value=choice)
+                                return gr.update(visible=True), gr.update(value=""), ""
+                            return gr.update(visible=False), gr.update(value=choice), choice
                         font_cn_dropdown.change(
                             _on_font_cn_select,
                             inputs=[font_cn_dropdown],
+                            outputs=[font_cn_custom_col, font_cn_custom, font_cn],
+                        )
+                        font_cn_custom.change(
+                            lambda v: v,
+                            inputs=[font_cn_custom],
                             outputs=[font_cn],
                         )
 
@@ -839,18 +846,24 @@ def build_app():
                             label="English Font",
                             info="Font for English text and numbers",
                         )
-                        font_en = gr.Textbox(
-                            label="Custom English Font",
-                            value="Arial",
-                            interactive=False,
-                        )
+                        with gr.Column(visible=False) as font_en_custom_col:
+                            font_en_custom = gr.Textbox(
+                                label="Custom English Font",
+                                value="",
+                            )
+                        font_en = gr.State("Arial")
                         def _on_font_en_select(choice):
                             if choice == "Custom":
-                                return gr.update(interactive=True, value="")
-                            return gr.update(interactive=False, value=choice)
+                                return gr.update(visible=True), gr.update(value=""), ""
+                            return gr.update(visible=False), gr.update(value=choice), choice
                         font_en_dropdown.change(
                             _on_font_en_select,
                             inputs=[font_en_dropdown],
+                            outputs=[font_en_custom_col, font_en_custom, font_en],
+                        )
+                        font_en_custom.change(
+                            lambda v: v,
+                            inputs=[font_en_custom],
                             outputs=[font_en],
                         )
                         mock_mode = gr.Checkbox(

--- a/app.py
+++ b/app.py
@@ -629,9 +629,11 @@ def build_app():
         # ================================================================
         with gr.Accordion("API Keys", open=False):
             gr.Markdown(
-                "**You do not need both keys.** Fill **at least one**: **OpenRouter** *or* **Google (Gemini)**. "
-                "If both are set, OpenRouter is preferred for automatic routing when available. "
-                "Proma and Local proxy require explicit model prefixes (`proma/`, `local/`)."
+                "Fill **at least one** API key. Supported providers:\n\n"
+                "- **Google (Gemini)** — text + image generation, bare model name auto-routes here\n"
+                "- **OpenRouter** — multi-model proxy, auto-routes when configured (priority over Gemini)\n"
+                "- **Proma** — cost-optimized proxy, requires `proma/` prefix (e.g. `proma/claude-sonnet-4-6`)\n"
+                "- **Local Proxy** — localhost:3000, requires `local/` prefix (e.g. `local/claude-opus-4-6`)"
             )
             with gr.Row():
                 openrouter_key_input = gr.Textbox(

--- a/configs/model_config.template.yaml
+++ b/configs/model_config.template.yaml
@@ -25,3 +25,5 @@ api_keys:
   openai_api_key: ""
   anthropic_api_key: ""
   openrouter_api_key: "" # e.g. "sk-or-v1-xxxxx". Set model_name to "openrouter/<model>" to use.
+  proma_api_key: "" # Proma API. Set model_name to "proma/<model>" to use.
+  local_api_key: "" # Local proxy at localhost:3000. Set model_name to "local/<model>" to use.

--- a/docs/eem3d_cnn_method.md
+++ b/docs/eem3d_cnn_method.md
@@ -1,0 +1,21 @@
+# CNN-based Classification of EEM-3D Fluorescence Data for Food Adulteration Detection
+
+---
+
+## Method Section Content
+
+### Convolutional Neural Network Architecture for EEM-3D Classification
+
+We propose a lightweight convolutional neural network (CNN) for classifying excitation-emission matrix (EEM) three-dimensional fluorescence spectra to detect and quantify food adulteration. The network takes as input the EEM-3D fluorescence map of size $91 \times 95$ pixels, corresponding to the excitation and emission wavelength dimensions, with adulteration levels ranging from 0% to 50%.
+
+**Feature Extraction Backbone.** The backbone consists of four sequential convolutional blocks, each comprising a $3 \times 3$ convolution, batch normalization (BN), and ReLU activation. The first block expands the input to 16 feature maps with spatial dimensions $45 \times 47$, followed by $2 \times 2$ max pooling. The second block increases the channel depth to 32 with output size $22 \times 23$, again followed by $2 \times 2$ max pooling. The third block further doubles the channels to 128 at spatial resolution $11 \times 11$, followed by $2 \times 2$ max pooling. The fourth and final convolutional block maintains 128 channels at $11 \times 11$ spatial resolution with no pooling applied, preserving spatial detail for downstream interpretability analysis via Gradient-weighted Class Activation Mapping (Grad-CAM).
+
+**Classification Head.** After the final convolutional block, a global average pooling (GAP) layer aggregates each feature map into a single scalar, producing a 128-dimensional feature vector. This vector is passed through a fully connected (FC) layer that maps to the output logits. The network supports two classification modes: (1) binary classification (adulterated vs. non-adulterated, 2 classes) and (2) multi-class classification (7 adulteration levels).
+
+**Interpretability.** The deliberate omission of pooling after the last convolutional layer preserves the $11 \times 11$ spatial resolution, enabling Grad-CAM to generate high-fidelity activation heatmaps that highlight the excitation-emission wavelength regions most discriminative for adulteration detection.
+
+---
+
+## Figure Caption
+
+**Figure X.** Architecture of the proposed CNN for EEM-3D fluorescence-based food adulteration classification. The input is a $91 \times 95$ EEM-3D fluorescence map with adulteration levels spanning 0--50%. The network comprises four convolutional blocks (Conv $3 \times 3$ + BN + ReLU), progressively increasing channel depth from 16 to 32, 128, and 128, with $2 \times 2$ max pooling applied after the first three blocks to reduce spatial dimensions from $45 \times 47$ to $22 \times 23$ and $11 \times 11$. The final block omits pooling to preserve spatial resolution for Grad-CAM interpretability analysis. A global average pooling (GAP) layer aggregates the 128 feature maps into a compact vector, which is projected by a fully connected (FC) layer to either 2 outputs (binary: adulterated vs. non-adulterated) or 7 outputs (multi-class adulteration level). The diagram should use a blue-to-red heatmap style for the EEM-3D input, warm orange/coral tones for convolutional feature maps with increasing depth depicted by block thickness, a distinct green block for GAP, and a purple block for the FC output. Spatial dimension and channel annotations should appear adjacent to each block. Use clean horizontal arrows for data flow, consistent drop shadows, and a sans-serif font for all labels.

--- a/docs/eem3d_pipeline_method.md
+++ b/docs/eem3d_pipeline_method.md
@@ -1,0 +1,29 @@
+# EEM Fluorescence Data Processing and Modeling Pipeline for Food Adulteration Detection
+
+---
+
+## Method Section Content
+
+### Data Processing and Modeling Pipeline
+
+The overall methodology follows an eleven-step pipeline that spans from raw spectral acquisition to model interpretation, as illustrated in the figure.
+
+**Data Acquisition and Preprocessing (Steps 1--4).** The pipeline begins with the raw EEM fluorescence spectral data. In Step 1, the raw data files are parsed and loaded into structured matrices. Step 2 computes the average pure-water blank matrix from replicate blank measurements, which serves as the baseline reference. Step 3 performs Raman scattering subtraction by removing the pure-water blank from each sample spectrum, eliminating the first-order Raman band that would otherwise interfere with fluorescence signals. Step 4 addresses Rayleigh scattering artifacts — both first-order and second-order — by masking or interpolating the diagonal regions in the EEM where excitation light directly leaks into the emission channel.
+
+**Chemometric Decomposition (Step 5).** Following scattering correction, Parallel Factor Analysis (PARAFAC) is applied to decompose the three-way EEM tensor into chemically meaningful fluorescent components. Each component corresponds to a unique excitation-emission profile representing a distinct fluorophore or chemical species in the sample, providing spectroscopic interpretability complementary to the data-driven CNN approach.
+
+**Quality Control and Visualization (Step 6).** The preprocessed EEM spectra are visualized as contour or surface plots for quality inspection, ensuring that scattering artifacts have been adequately removed and that fluorescence features are clearly resolved before model training.
+
+**Dataset Construction and Splitting (Step 7).** The cleaned EEM matrices are organized into a labeled dataset with corresponding adulteration levels. The dataset is split into training, validation, and test subsets using a stratified sampling strategy to ensure balanced class representation across all partitions.
+
+**Parallel Model Construction (Steps 8a--8b).** Two classification models are constructed in parallel: (a) a CNN model (Step 8a) that directly ingests the two-dimensional EEM matrix as image-like input and learns hierarchical spatial-spectral features through convolutional layers; and (b) an SVM baseline model (Step 8b) that operates on vectorized or PARAFAC-derived features, serving as a conventional chemometric benchmark for performance comparison.
+
+**Training, Evaluation, and Comparison (Steps 9--10).** Both models are trained and evaluated using consistent cross-validation protocols and performance metrics (Step 9). Step 10 provides a systematic comparison of classification performance through confusion matrices, ROC curves, and accuracy metrics, quantifying the advantage of the deep learning approach over the traditional SVM baseline.
+
+**Interpretability Analysis (Step 11).** Finally, Grad-CAM activation maps generated from the CNN are jointly analyzed with the PARAFAC-decomposed fluorescent components (Step 11). This combined interpretation links the CNN's learned discriminative regions in the EEM space to chemically identifiable fluorophores, bridging the gap between data-driven prediction and spectroscopic domain knowledge.
+
+---
+
+## Figure Caption
+
+**Figure X.** Flowchart of the complete EEM fluorescence data processing and modeling pipeline for food adulteration detection. The pipeline proceeds from raw EEM spectral data through sequential preprocessing steps: data parsing and loading (Step 1), pure-water blank averaging (Step 2), Raman scattering subtraction (Step 3), and Rayleigh scattering correction (Step 4). A branching path leads to PARAFAC fluorescent component decomposition (Step 5) for chemometric analysis. After EEM visualization and quality inspection (Step 6), the dataset is constructed and partitioned (Step 7). Two parallel modeling tracks are pursued: a CNN-based classifier (Step 8a) and an SVM baseline model (Step 8b). Both converge at model training and evaluation (Step 9), followed by comparative performance visualization (Step 10). The pipeline concludes with joint Grad-CAM and PARAFAC interpretation (Step 11), linking CNN-learned discriminative EEM regions to chemically meaningful fluorescent components. The diagram should use a vertical top-to-bottom flow with rounded rectangles for each step, diamond-shaped decision/branch nodes where the pipeline diverges (Steps 4→5 and 7→8a/8b) and converges (8a/8b→9), light purple/lavender fill for step boxes, dark borders, and clear directional arrows. All text labels inside the figure must be in Chinese.

--- a/docs/speed_prediction_method.md
+++ b/docs/speed_prediction_method.md
@@ -1,0 +1,51 @@
+# Attention-based Encoder-Decoder for Multi-step Speed Prediction
+
+## Method Section Content (paste into "Method Section Content" box)
+
+### Encoder-Decoder Architecture with Attention
+
+We propose an attention-based encoder-decoder framework for multi-step speed prediction. The architecture consists of three tightly coupled components: (1) an LSTM encoder that summarizes historical driving data, (2) an attention module that dynamically retrieves relevant historical context, and (3) an autoregressive LSTM decoder that fuses multi-source features for step-wise prediction.
+
+**Encoder.** The encoder is a standard LSTM that ingests the historical observation tensor $\mathbf{X} \in \mathbb{R}^{B \times T_h \times D_h}$ (denoted `[B, HIST_SEQ_LEN, HIST_FEAT_DIM]`), where the input at each step is the historical driving features. Internally, the LSTM cell receives the previous cell state $C_{t-1}$ and hidden state $h_{t-1}$, and applies four gating operations — three Sigmoid gates (input, forget, output) and one Tanh gate — combined via element-wise multiplication ($\otimes$) and addition ($\oplus$) to produce the updated cell state $C_t$ and hidden state. The encoder call is:
+
+```
+encoder_outputs, hidden, cell = self.encoder(hist_data, debug=debug)
+```
+
+This yields: (a) `encoder_outputs` — the full sequence of hidden representations across all historical time steps, shaped `[B, HIST_SEQ_LEN, 2*ENC_HIDDEN_DIM]`; and (b) the final `hidden` and `cell` states shaped `[B, dec_hid_dim]`, which initialize the decoder.
+
+**Attention.** At each decoder time step, the attention module queries the full encoder output sequence with the decoder's last-layer hidden state to compute a context vector:
+
+```
+context_vector, attn_weights = self.attention(hidden[-1], encoder_outputs)
+```
+
+The context vector selectively retrieves the most informative historical information for the current prediction step. A separate context vector is computed at each decoder step $t, t{+}1, t{+}2, \ldots$
+
+**Decoder.** The decoder is an autoregressive LSTM that generates predictions over $T_p$ future steps. At each step $t$, the decoder receives two external inputs:
+- Speed$_t$ — the previously predicted (or ground-truth) speed
+- Navigation/environment features$_t$ shaped `[B, PRED_SEQ_LEN, NAV_FEAT_DIM]` — road-level attributes such as gradient, speed limit, and traffic context
+
+These are combined into `dec_input`, concatenated with the attention context vector, and fed into the LSTM:
+
+```
+lstm_input = torch.cat((dec_input, context_vector), dim=2)
+output, (hidden, cell) = self.lstm(lstm_input, (hidden, cell))
+```
+
+The LSTM produces `output` and passes the updated hidden state and cell state to the next time step.
+
+**Three-way Feature Fusion and Prediction.** The final prediction at each step fuses three information sources through concatenation and a fully-connected projection:
+
+```
+pred_input = torch.cat((output, context_vector, dec_input), dim=2)
+prediction = self.fc_out(pred_input)
+```
+
+The three sources are: (1) `output` — the decoder LSTM's current-step output capturing temporal dynamics; (2) `context_vector` — historically relevant information retrieved by attention; (3) `dec_input` — the current external input including navigation and environment data. The FC layer maps the high-dimensional fused representation down to a single scalar, yielding the predicted speed. This process repeats autoregressively: the predicted speed feeds back as input to the next decoder step, producing speed$_{t+1}$, speed$_{t+2}$, speed$_{t+3}$, ...
+
+---
+
+## Figure Caption (paste into "Figure Caption" box)
+
+**Figure 1.** Overview of the proposed attention-based encoder-decoder architecture for multi-step speed prediction. *(Left)* The LSTM encoder processes historical input `[B, HIST_SEQ_LEN, HIST_FEAT_DIM]` through gated operations (Sigmoid ×3, Tanh ×1) with element-wise multiply ($\otimes$) and addition ($\oplus$), producing the full encoder output sequence (`[B, HIST_SEQ_LEN, 2*ENC_HIDDEN_DIM]`) and the final hidden/cell states `[B, dec_hid_dim]`. *(Top)* An attention module queries encoder outputs with the decoder hidden state to compute a context vector at each step, selectively retrieving relevant historical information. *(Right, shaded region)* The autoregressive LSTM decoder generates future speed predictions step by step: at each time step $t$, the decoder concatenates the current speed and navigation/environment features (`[B, PRED_SEQ_LEN, NAV_FEAT_DIM]`) with the context vector as LSTM input, then fuses the LSTM output, context vector, and decoder input via three-way concatenation before a fully-connected layer projects to the predicted speed (high-dimensional to scalar). Hidden states propagate between consecutive LSTM cells to maintain temporal continuity. The diagram should use distinct colored regions for each module (blue/cyan for encoder, yellow/orange for attention, pink/coral for decoder), with icons such as gear for LSTM cells, magnifying glass for attention, speedometer for output, and clock icons for temporal indices. Use gradient-filled arrows with varying thickness to distinguish primary data flow from skip connections, rounded rectangles with soft drop shadows, tensor shape annotations in monospace labels, and a compact legend box.

--- a/scripts/fix_text.py
+++ b/scripts/fix_text.py
@@ -19,7 +19,6 @@ from datetime import datetime
 from difflib import SequenceMatcher
 from pathlib import Path
 
-import sys
 import numpy as np
 from openai import OpenAI
 from PIL import Image, ImageDraw

--- a/scripts/fix_text.py
+++ b/scripts/fix_text.py
@@ -19,12 +19,20 @@ from datetime import datetime
 from difflib import SequenceMatcher
 from pathlib import Path
 
+import sys
 import numpy as np
-import Foundation
-import Vision
 from openai import OpenAI
 from PIL import Image, ImageDraw
-from Quartz import CIImage
+
+try:
+    import Foundation
+    import Vision
+    from Quartz import CIImage
+except ModuleNotFoundError:
+    if sys.platform != "darwin":
+        print("Error: fix_text.py requires macOS (Vision framework). Not supported on this platform.")
+        sys.exit(1)
+    raise
 
 
 # --- Config ---

--- a/scripts/fix_text.py
+++ b/scripts/fix_text.py
@@ -98,7 +98,7 @@ def vision_ocr(img_path: str) -> list[dict]:
         ly2 = int((1 - box.origin.y) * img_h)
 
         char_bboxes = []
-        for i in range(len(text)):
+        for i, ch in enumerate(text):
             char_range = Foundation.NSRange(i, 1)
             box_obs, _ = candidate.boundingBoxForRange_error_(char_range, None)
             if box_obs:
@@ -107,7 +107,7 @@ def vision_ocr(img_path: str) -> list[dict]:
                 cy1 = int((1 - b.origin.y - b.size.height) * img_h)
                 cx2 = int((b.origin.x + b.size.width) * img_w)
                 cy2 = int((1 - b.origin.y) * img_h)
-                char_bboxes.append({"char": text[i], "bbox": [cx1, cy1, cx2, cy2]})
+                char_bboxes.append({"char": ch, "bbox": [cx1, cy1, cx2, cy2]})
 
         results.append({
             "text": text,
@@ -163,10 +163,6 @@ def proofread(ocr_results: list[dict], client: OpenAI, model: str, reference: st
         return None
 
     result = _parse_response(raw)
-
-    if result is None:
-        print("[WARN] LLM 返回内容无法解析为JSON")
-        return None
     if not isinstance(result, dict):
         return None
 

--- a/scripts/fix_text.py
+++ b/scripts/fix_text.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""
+AI生成图像文字纠错工具。
+
+流程：macOS Vision OCR（逐字定位） → LLM校对 → 标注 + 可选遮盖
+遮盖方案：1px padding + 亮像素中位数背景色填充
+
+Usage:
+    python scripts/fix_text.py image.png
+    python scripts/fix_text.py image.png --mask
+    python scripts/fix_text.py image.png --model openai/gpt-oss-20b
+"""
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime
+from difflib import SequenceMatcher
+from pathlib import Path
+
+import numpy as np
+import Foundation
+import Vision
+from openai import OpenAI
+from PIL import Image, ImageDraw
+from Quartz import CIImage
+
+
+# --- Config ---
+
+LM_STUDIO_BASE = "http://localhost:1234/v1"
+DEFAULT_MODEL = "openai/gpt-oss-20b"
+MASK_PADDING = 1       # px, Vision bbox 外扩
+BG_SAMPLE_MARGIN = 15  # px, 背景色采样范围
+
+
+# --- Helpers ---
+
+def _parse_response(raw: str) -> dict | list | None:
+    raw = re.sub(r"<think>.*?</think>", "", raw, flags=re.DOTALL).strip()
+    m = re.search(r"```(?:json)?\s*(\{.*?\}|\[.*?\])\s*```", raw, re.DOTALL)
+    if m:
+        raw = m.group(1)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        print(f"[WARN] 模型返回非JSON:\n{raw[:300]}")
+        return None
+
+
+def _text_similarity(a: str, b: str) -> float:
+    return SequenceMatcher(None, a, b).ratio()
+
+
+# --- Step 1: macOS Vision OCR ---
+
+def vision_ocr(img_path: str) -> list[dict]:
+    """macOS Vision 文字识别，返回行级+逐字 bbox。"""
+    img = Image.open(img_path)
+    img_w, img_h = img.size
+
+    url = Foundation.NSURL.fileURLWithPath_(str(img_path))
+    ci_image = CIImage.imageWithContentsOfURL_(url)
+    if ci_image is None:
+        print(f"[ERROR] Vision 无法加载图像: {img_path}")
+        return []
+
+    img.close()
+
+    request = Vision.VNRecognizeTextRequest.alloc().init()
+    request.setRecognitionLanguages_(["zh-Hans", "en"])
+    request.setRecognitionLevel_(Vision.VNRequestTextRecognitionLevelAccurate)
+    request.setUsesLanguageCorrection_(False)
+
+    handler = Vision.VNImageRequestHandler.alloc().initWithCIImage_options_(ci_image, None)
+    success, error = handler.performRequests_error_([request], None)
+    if not success:
+        print(f"[ERROR] Vision OCR 失败: {error}")
+        return []
+
+    if not request.results():
+        return []
+
+    results = []
+    for obs in request.results():
+        candidates = obs.topCandidates_(1)
+        if not candidates:
+            continue
+        candidate = candidates[0]
+        text = candidate.string()
+        conf = obs.confidence()
+
+        box = obs.boundingBox()
+        lx1 = int(box.origin.x * img_w)
+        ly1 = int((1 - box.origin.y - box.size.height) * img_h)
+        lx2 = int((box.origin.x + box.size.width) * img_w)
+        ly2 = int((1 - box.origin.y) * img_h)
+
+        char_bboxes = []
+        for i in range(len(text)):
+            char_range = Foundation.NSRange(i, 1)
+            box_obs, _ = candidate.boundingBoxForRange_error_(char_range, None)
+            if box_obs:
+                b = box_obs.boundingBox()
+                cx1 = int(b.origin.x * img_w)
+                cy1 = int((1 - b.origin.y - b.size.height) * img_h)
+                cx2 = int((b.origin.x + b.size.width) * img_w)
+                cy2 = int((1 - b.origin.y) * img_h)
+                char_bboxes.append({"char": text[i], "bbox": [cx1, cy1, cx2, cy2]})
+
+        results.append({
+            "text": text,
+            "bbox": [lx1, ly1, lx2, ly2],
+            "confidence": conf,
+            "chars": char_bboxes,
+        })
+
+    return results
+
+
+# --- Step 2: LLM 校对 ---
+
+def proofread(ocr_results: list[dict], client: OpenAI, model: str, reference: str | None = None) -> list[dict] | None:
+    seen = set()
+    unique = []
+    for ocr in ocr_results:
+        if ocr["text"] not in seen:
+            seen.add(ocr["text"])
+            unique.append(ocr)
+
+    text_lines = [f"{i+1}. {ocr['text']}" for i, ocr in enumerate(unique)]
+    ocr_block = "\n".join(text_lines)
+
+    prompt = f"""以下是AI生成的学术图表中OCR识别出的文字（已去重）。请检查错别字（如形近字"力"→"热"）。
+
+重要：
+- 这是图表，相同文字在不同位置重复出现是正常的，不是错误
+- 文字重复、语句不通顺可能是OCR识别问题，不一定是图中的错字
+- 只报告你非常确信是形近字替换、笔画错误等真正错别字的情况
+
+{ocr_block}
+
+返回JSON: {{"errors": [{{"index": 序号, "wrong": "错误文字", "correct": "修正后", "note": "说明"}}]}}
+没有错误返回: {{"errors": []}}"""
+    if reference:
+        prompt += f"\n参考: {reference}"
+
+    try:
+        resp = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.1,
+            max_tokens=2048,
+        )
+        raw = (resp.choices[0].message.content or "").strip()
+    except Exception as e:
+        print(f"[ERROR] LLM 请求失败: {e}")
+        return None  # None = failure, [] = no errors
+
+    if not raw:
+        print("[WARN] LLM 返回空内容")
+        return None
+
+    result = _parse_response(raw)
+
+    if result is None:
+        print("[WARN] LLM 返回内容无法解析为JSON")
+        return None
+    if not isinstance(result, dict):
+        return None
+
+    errors = result.get("errors") or []
+    if not isinstance(errors, list):
+        return None
+
+    normalized = []
+    for e in errors:
+        if not isinstance(e, dict):
+            continue
+        wrong = e.get("wrong", "")
+        correct = e.get("correct", "")
+        if wrong and wrong != correct:
+            normalized.append({"wrong": wrong, "correct": correct, "note": e.get("note", "")})
+    return normalized
+
+
+# --- Step 3: 匹配错误到逐字 bbox ---
+
+def match_errors(errors: list[dict], ocr_results: list[dict]) -> list[dict]:
+    matched = []
+
+    for err in errors:
+        wrong = err["wrong"]
+        best_ocr = None
+        best_score = 0.0
+
+        for ocr in ocr_results:
+            ocr_text = ocr["text"]
+            if wrong in ocr_text:
+                score = 0.95
+            elif ocr_text in wrong:
+                score = 0.85
+            else:
+                score = _text_similarity(wrong, ocr_text)
+            if score > best_score:
+                best_score = score
+                best_ocr = ocr
+
+        if not best_ocr or best_score < 0.3:
+            print(f"    [WARN] 未匹配:「{wrong}」")
+            continue
+
+        ocr_text = best_ocr["text"]
+        chars = best_ocr.get("chars", [])
+
+        if wrong == ocr_text:
+            char_bboxes = [c["bbox"] for c in chars]
+        elif wrong in ocr_text and chars:
+            start_idx = ocr_text.index(wrong)
+            end_idx = start_idx + len(wrong)
+            char_bboxes = [chars[i]["bbox"] for i in range(start_idx, end_idx) if i < len(chars)]
+        else:
+            char_bboxes = [best_ocr["bbox"]]
+
+        matched.append({
+            **err,
+            "line_bbox": best_ocr["bbox"],
+            "char_bboxes": char_bboxes,
+            "ocr_text": ocr_text,
+        })
+        print(f"    匹配: 「{wrong}」 ↔ OCR「{ocr_text}」 ({len(char_bboxes)} 字符)")
+
+    return matched
+
+
+# --- Step 4: 标注 ---
+
+def annotate_image(img: Image.Image, matched: list[dict]) -> Image.Image:
+    result = img.copy().convert("RGB")
+    draw = ImageDraw.Draw(result)
+
+    for i, item in enumerate(matched):
+        x1, y1, x2, y2 = item["line_bbox"]
+        for offset in range(2):
+            draw.rectangle([x1 - offset, y1 - offset, x2 + offset, y2 + offset], outline=(255, 0, 0))
+        label = f"{i+1}"
+        lx, ly = max(0, x1 - 1), max(0, y1 - 20)
+        draw.rectangle([lx, ly, lx + 14 * len(label), ly + 18], fill=(255, 0, 0))
+        draw.text((lx + 2, ly), label, fill=(255, 255, 255))
+
+    return result
+
+
+# --- Step 5: 像素级遮盖 ---
+
+def _sample_bg_color(img_arr: np.ndarray, x1: int, y1: int, x2: int, y2: int) -> np.ndarray:
+    """从 bbox 周围采样亮像素中位数作为背景色。"""
+    img_h, img_w = img_arr.shape[:2]
+    mx1 = max(0, x1 - BG_SAMPLE_MARGIN)
+    my1 = max(0, y1 - BG_SAMPLE_MARGIN)
+    mx2 = min(img_w, x2 + BG_SAMPLE_MARGIN)
+    my2 = min(img_h, y2 + BG_SAMPLE_MARGIN)
+
+    region = img_arr[my1:my2, mx1:mx2]
+    if region.size == 0:
+        return np.array([255, 255, 255], dtype=np.uint8)
+
+    gray = np.mean(region, axis=2)
+    threshold = np.percentile(gray, 75)
+    bg_pixels = region[gray >= threshold]
+
+    if len(bg_pixels) > 0:
+        return np.median(bg_pixels, axis=0).astype(np.uint8)
+    return np.array([255, 255, 255], dtype=np.uint8)
+
+
+def mask_errors(img: Image.Image, matched: list[dict]) -> Image.Image:
+    """逐字遮盖：1px padding + 亮像素中位数背景色填充。"""
+    img_arr = np.array(img.convert("RGB")).copy()
+    img_h, img_w = img_arr.shape[:2]
+
+    for item in matched:
+        for cb in item["char_bboxes"]:
+            x1, y1, x2, y2 = cb
+            x1 = max(0, x1 - MASK_PADDING)
+            y1 = max(0, y1 - MASK_PADDING)
+            x2 = min(img_w, x2 + MASK_PADDING)
+            y2 = min(img_h, y2 + MASK_PADDING)
+
+            if x2 <= x1 or y2 <= y1:
+                continue
+
+            bg = _sample_bg_color(img_arr, x1, y1, x2, y2)
+            img_arr[y1:y2, x1:x2] = bg
+
+        print(f"  遮盖: 「{item['wrong']}」→「{item['correct']}」 ({len(item['char_bboxes'])} 字符)")
+
+    return Image.fromarray(img_arr)
+
+
+# --- Step 6: 报告 ---
+
+def generate_report(img_path, img_size, errors, matched, model):
+    lines = [
+        f"# 文字校对报告",
+        f"",
+        f"- **图像**: {img_path.name} ({img_size[0]}x{img_size[1]})",
+        f"- **日期**: {datetime.now().strftime('%Y-%m-%d %H:%M')}",
+        f"- **模型**: {model}",
+        f"- **检测到错误**: {len(errors)} 处",
+        f"",
+    ]
+
+    if matched:
+        lines.append("## 错误列表\n")
+        lines.append("| # | 错误文字 | 修正为 | 说明 |")
+        lines.append("|---|----------|--------|------|")
+        for i, m in enumerate(matched):
+            lines.append(f"| {i+1} | {m['wrong']} | {m['correct']} | {m.get('note','')} |")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# --- Main ---
+
+def main():
+    parser = argparse.ArgumentParser(description="AI生成图像文字纠错")
+    parser.add_argument("image", help="输入图像路径")
+    parser.add_argument("-r", "--reference", help="参考文本")
+    parser.add_argument("-o", "--output", help="输出路径前缀")
+    parser.add_argument("--mask", action="store_true", help="启用遮盖模式")
+    parser.add_argument("--api-base", default=LM_STUDIO_BASE)
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    args = parser.parse_args()
+
+    img_path = Path(args.image)
+    if not img_path.exists():
+        print(f"错误: 找不到 {img_path}")
+        sys.exit(1)
+
+    try:
+        img = Image.open(img_path)
+    except Exception as e:
+        print(f"错误: 无法打开图像 {img_path}: {e}")
+        sys.exit(1)
+    print(f"图像: {img_path.name} ({img.size[0]}x{img.size[1]})")
+    print(f"模型: {args.model}\n")
+
+    # Step 1
+    print("  [1/3] macOS Vision OCR...")
+    ocr_results = vision_ocr(str(img_path))
+    if not ocr_results:
+        print("\n  OCR 未检测到任何文字，退出。")
+        sys.exit(1)
+    print(f"         检测到 {len(ocr_results)} 个文字区域")
+
+    # Step 2
+    client = OpenAI(base_url=args.api_base, api_key="not-needed")
+    print("  [2/3] LLM 校对中...")
+    errors = proofread(ocr_results, client, args.model, args.reference)
+
+    if errors is None:
+        print("\n  校对失败，请检查 LLM 服务是否正常。")
+        sys.exit(1)
+    if not errors:
+        print("\n  未发现错误。")
+        return
+
+    print(f"\n  发现 {len(errors)} 处错误:")
+    for i, err in enumerate(errors):
+        print(f"    [{i+1}] 「{err['wrong']}」→「{err['correct']}」  {err.get('note','')}")
+
+    # Step 3
+    print("\n  [3/3] 匹配到逐字位置...")
+    matched = match_errors(errors, ocr_results)
+
+    if not matched:
+        print("  无法定位。")
+        return
+
+    # 输出
+    out_prefix = args.output or str(img_path.parent / img_path.stem)
+
+    annotated = annotate_image(img, matched)
+    ann_path = out_prefix + "_annotated.png"
+    annotated.save(ann_path)
+    print(f"\n  标注图: {ann_path}")
+
+    if args.mask:
+        masked = mask_errors(img, matched)
+        mask_path = out_prefix + "_masked.png"
+        masked.save(mask_path)
+        print(f"  遮盖图: {mask_path}")
+
+    report = generate_report(img_path, img.size, errors, matched, args.model)
+    report_path = out_prefix + "_report.md"
+    Path(report_path).write_text(report, encoding="utf-8")
+    print(f"  报告: {report_path}")
+
+    print("\n完成!")
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/config.py
+++ b/utils/config.py
@@ -45,36 +45,32 @@ class ExpConfig:
         if hasattr(time, "tzset"):
             time.tzset()  # Only available on Unix; no-op guard for Windows
         
-        # Fallback to yaml config if no model name provided
+        # Resolve model names: yaml config -> environment variables -> hard defaults
         if not self.main_model_name or not self.image_gen_model_name:
             import yaml
             config_path = self.work_dir / "configs" / "model_config.yaml"
             if config_path.exists():
                 with open(config_path, "r", encoding="utf-8") as f:
-                    model_config_data = yaml.safe_load(f) or {}
+                    defaults = (yaml.safe_load(f) or {}).get("defaults", {})
                     if not self.main_model_name:
-                        self.main_model_name = model_config_data.get("defaults", {}).get("main_model_name", "")
+                        self.main_model_name = defaults.get("main_model_name", "")
                     if not self.image_gen_model_name:
-                        self.image_gen_model_name = model_config_data.get("defaults", {}).get("image_gen_model_name", "")
-        # Fallback to environment variables
-        if not self.main_model_name:
-            self.main_model_name = os.environ.get("MAIN_MODEL_NAME", "")
-        if not self.image_gen_model_name:
-            self.image_gen_model_name = os.environ.get("IMAGE_GEN_MODEL_NAME", "")
-        # Hard defaults so model name is never empty
-        if not self.main_model_name:
-            self.main_model_name = "gemini-3.1-pro-preview"
-            print(f"Warning: main_model_name not configured, falling back to '{self.main_model_name}'. "
-                  "Set it in configs/model_config.yaml or via --main-model-name.")
-        if not self.image_gen_model_name:
-            self.image_gen_model_name = "gemini-3.1-flash-image-preview"
-            print(f"Warning: image_gen_model_name not configured, falling back to '{self.image_gen_model_name}'. "
-                  "Set it in configs/model_config.yaml or via --image-gen-model-name.")
+                        self.image_gen_model_name = defaults.get("image_gen_model_name", "")
+
+        for attr, env_var, fallback in [
+            ("main_model_name", "MAIN_MODEL_NAME", "gemini-3.1-pro-preview"),
+            ("image_gen_model_name", "IMAGE_GEN_MODEL_NAME", "gemini-3.1-flash-image-preview"),
+        ]:
+            if not getattr(self, attr):
+                setattr(self, attr, os.environ.get(env_var, ""))
+            if not getattr(self, attr):
+                setattr(self, attr, fallback)
+                print(f"Warning: {attr} not configured, falling back to '{fallback}'. "
+                      f"Set it in configs/model_config.yaml or via --{attr.replace('_', '-')}.")
         self.timestamp = (
             time.strftime("%m%d_%H%M") if self.timestamp is None else self.timestamp
         )
         self.exp_name = f"{self.timestamp}_{self.retrieval_setting}ret_{self.exp_mode}_{self.split_name}"
 
-        # mkdir result_dir if not exists
         self.result_dir = self.work_dir / "results" / f"{self.dataset_name}_{self.task_name}"
         self.result_dir.mkdir(exist_ok=True, parents=True)

--- a/utils/config.py
+++ b/utils/config.py
@@ -27,7 +27,7 @@ from typing import Literal
 class ExpConfig:
     """Experiment configuration"""
 
-    dataset_name: Literal["PaperBananaBench"]
+    dataset_name: Literal["PaperBananaBench", "Demo"]
     task_name: Literal["diagram", "plot"] = "diagram"
     split_name: str = "test"
     temperature: float = 1.0

--- a/utils/generation_utils.py
+++ b/utils/generation_utils.py
@@ -20,12 +20,9 @@ import json
 import asyncio
 import base64
 from io import BytesIO
-from functools import partial
-from ast import literal_eval
 from typing import List, Dict, Any
 
 import httpx
-import aiofiles
 from PIL import Image
 from google import genai
 from google.genai import types
@@ -186,30 +183,20 @@ async def call_gemini_with_retry_async(
 
     result_list = []
     target_candidate_count = config.candidate_count
-    # Gemini API max candidate count is 8. Cap without mutating the original config.
     if target_candidate_count > 8:
         import copy as _copy
         config = _copy.copy(config)
         config.candidate_count = 8
 
-    current_contents = contents
     attempt = 0
     while attempt < max_attempts:
         try:
-            # Use global client
-            client = gemini_client
-
-            # Convert generic content list to Gemini's format right before the API call
-            gemini_contents = _convert_to_gemini_parts(current_contents)
-            response = await client.aio.models.generate_content(
+            gemini_contents = _convert_to_gemini_parts(contents)
+            response = await gemini_client.aio.models.generate_content(
                 model=model_name, contents=gemini_contents, config=config
             )
 
-            # If we are using Image Generation models to generate images
-            if (
-                "nanoviz" in model_name
-                or "image" in model_name
-            ):
+            if "nanoviz" in model_name or "image" in model_name:
                 raw_response_list = []
                 if not response.candidates or not response.candidates[0].content.parts:
                     print(
@@ -219,16 +206,13 @@ async def call_gemini_with_retry_async(
                     attempt += 1
                     continue
 
-                # In this mode, we can only have one candidate
                 for part in response.candidates[0].content.parts:
                     if part.inline_data:
-                        # Append base64 encoded image data to raw_response_list
                         raw_response_list.append(
                             base64.b64encode(part.inline_data.data).decode("utf-8")
                         )
                         break
 
-            # Otherwise, for text generation models
             else:
                 raw_response_list = [
                     part.text
@@ -250,7 +234,6 @@ async def call_gemini_with_retry_async(
             is_overload_error = "503" in error_str or "unavailable" in error_lower
             is_image_model = "image" in model_name or "nanoviz" in model_name
 
-            # --- 400: Region restriction → abort immediately ---
             if is_region_error and is_image_model:
                 msg = (
                     f"❌ Model {model_name} blocked by region restriction (400){context_msg}. "
@@ -262,7 +245,6 @@ async def call_gemini_with_retry_async(
                 })
                 raise ImageGenerationError(msg)
 
-            # --- 503: Overloaded → retry 5 times, then fallback, then abort ---
             if is_overload_error and is_image_model:
                 if attempt < max_attempts - 1:
                     current_delay = min(retry_delay * (2 ** attempt), 30)
@@ -274,7 +256,6 @@ async def call_gemini_with_retry_async(
                     attempt += 1
                     continue
                 else:
-                    # All retries exhausted for this model, try fallback
                     fallback = _get_fallback_model(model_name)
                     if fallback and fallback != model_name:
                         print(
@@ -288,7 +269,6 @@ async def call_gemini_with_retry_async(
                         attempt = 0
                         continue
                     else:
-                        # No more fallback models
                         msg = (
                             f"❌ All image models exhausted (503){context_msg}. "
                             f"Last model: {model_name}. All retries and fallbacks failed."
@@ -299,7 +279,6 @@ async def call_gemini_with_retry_async(
                         })
                         raise ImageGenerationError(msg)
 
-            # --- Other errors: normal retry with backoff ---
             current_delay = min(retry_delay * (2 ** attempt), 30)
             print(
                 f"Attempt {attempt + 1} for model {model_name} failed{context_msg}: {e}. Retrying in {current_delay} seconds..."
@@ -316,15 +295,14 @@ async def call_gemini_with_retry_async(
     return result_list
 
 
-# Image model fallback chain: on 503 overload, try next model; on 400 region block, abort immediately
 _IMAGE_MODEL_FALLBACK_CHAIN = [
     "gemini-3.1-flash-image-preview",
     "gemini-3-pro-image-preview",
     "gemini-2.5-flash-image",
 ]
 
-_fallback_used = {}  # Track which models already fell back to avoid loops
-fallback_events = []  # Collect fallback events for UI display
+_fallback_used = {}
+fallback_events = []
 
 
 def _get_fallback_model(current_model: str) -> str:
@@ -342,39 +320,12 @@ def _get_fallback_model(current_model: str) -> str:
     return current_model
 
 def _convert_to_claude_format(contents: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """
-    Converts the generic content list to Claude's API format.
-    Currently, the formats are identical, so this acts as a pass-through
-    for architectural consistency and future-proofing.
-
-    Claude API's format:
-    [
-        {"type": "text", "text": "some text"},
-        {"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": "..."}},
-        ...
-    ]
-    """
+    """Convert generic content list to Claude's API format (currently identical)."""
     return contents
 
 
 def _convert_to_openai_format(contents: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """
-    Converts the generic content list (Claude format) to OpenAI's API format.
-    
-    Claude format:
-    [
-        {"type": "text", "text": "some text"},
-        {"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": "..."}},
-        ...
-    ]
-    
-    OpenAI format:
-    [
-        {"type": "text", "text": "some text"},
-        {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}},
-        ...
-    ]
-    """
+    """Convert generic content list to OpenAI's API format (image -> image_url)."""
     openai_contents = []
     for item in contents:
         if item.get("type") == "text":
@@ -413,18 +364,11 @@ async def call_claude_with_retry_async(
     max_output_tokens = config["max_output_tokens"]
     response_text_list = []
 
-    # --- Preparation Phase ---
-    # Convert to the Claude-specific format and perform an initial optimistic resize.
-    current_contents = contents
-
-    # --- Validation and Remediation Phase ---
-    # We loop until we get a single successful response, proving the input is valid.
-    # Note that this check is required because Claude only has 128k / 256k context windows.
-    # For Gemini series that support 1M, we do not need this step.
+    # Validate input with a single request first (Claude has smaller context windows).
     is_input_valid = False
     for attempt in range(max_attempts):
         try:
-            claude_contents = _convert_to_claude_format(current_contents)
+            claude_contents = _convert_to_claude_format(contents)
             # Attempt to generate the very first candidate.
             first_response = await anthropic_client.messages.create(
                 model=model_name,
@@ -438,28 +382,19 @@ async def call_claude_with_retry_async(
             break
 
         except Exception as e:
-            error_str = str(e).lower()
             context_msg = f" for {error_context}" if error_context else ""
-            print(
-                f"Validation attempt {attempt + 1} failed{context_msg}: {error_str}. Retrying in {retry_delay} seconds..."
-            )
+            print(f"Attempt {attempt + 1} failed{context_msg}: {e}. Retrying in {retry_delay}s...")
             if attempt < max_attempts - 1:
                 await asyncio.sleep(retry_delay)
 
-    # --- Sampling Phase ---
     if not is_input_valid:
-        print(
-            f"Error: All {max_attempts} attempts failed to validate the input{context_msg}. Returning errors."
-        )
+        context_msg = f" for {error_context}" if error_context else ""
+        print(f"Error: All {max_attempts} Claude attempts failed{context_msg}.")
         return ["Error"] * candidate_num
 
-    # We already have 1 successful candidate, now generate the rest.
     remaining_candidates = candidate_num - 1
     if remaining_candidates > 0:
-        print(
-            f"Input validated. Now generating remaining {remaining_candidates} candidates..."
-        )
-        valid_claude_contents = _convert_to_claude_format(current_contents)
+        valid_claude_contents = _convert_to_claude_format(contents)
         tasks = [
             anthropic_client.messages.create(
                 model=model_name,
@@ -496,17 +431,10 @@ async def call_openai_with_retry_async(
     max_completion_tokens = config["max_completion_tokens"]
     response_text_list = []
 
-    # --- Preparation Phase ---
-    # Convert to the OpenAI-specific format
-    current_contents = contents
-
-    # --- Validation and Remediation Phase ---
-    # We loop until we get a single successful response, proving the input is valid.
     is_input_valid = False
     for attempt in range(max_attempts):
         try:
-            openai_contents = _convert_to_openai_format(current_contents)
-            # Attempt to generate the very first candidate.
+            openai_contents = _convert_to_openai_format(contents)
             first_response = await openai_client.chat.completions.create(
                 model=model_name,
                 messages=[
@@ -525,31 +453,22 @@ async def call_openai_with_retry_async(
                 continue
             response_text_list.append(content)
             is_input_valid = True
-            break  # Exit the validation loop
+            break
 
         except Exception as e:
-            error_str = str(e).lower()
             context_msg = f" for {error_context}" if error_context else ""
-            print(
-                f"Validation attempt {attempt + 1} failed{context_msg}: {error_str}. Retrying in {retry_delay} seconds..."
-            )
+            print(f"OpenAI attempt {attempt + 1} failed{context_msg}: {e}. Retrying in {retry_delay}s...")
             if attempt < max_attempts - 1:
                 await asyncio.sleep(retry_delay)
 
-    # --- Sampling Phase ---
     if not is_input_valid:
-        print(
-            f"Error: All {max_attempts} attempts failed to validate the input{context_msg}. Returning errors."
-        )
+        context_msg = f" for {error_context}" if error_context else ""
+        print(f"Error: All {max_attempts} OpenAI attempts failed{context_msg}.")
         return ["Error"] * candidate_num
 
-    # We already have 1 successful candidate, now generate the rest.
     remaining_candidates = candidate_num - 1
     if remaining_candidates > 0:
-        print(
-            f"Input validated. Now generating remaining {remaining_candidates} candidates..."
-        )
-        valid_openai_contents = _convert_to_openai_format(current_contents)
+        valid_openai_contents = _convert_to_openai_format(contents)
         tasks = [
             openai_client.chat.completions.create(
                 model=model_name,
@@ -585,20 +504,15 @@ async def call_openai_image_generation_with_retry_async(
     background = config.get("background", "opaque")
     output_format = config.get("output_format", "png")
     
-    # Base parameters for all models
     gen_params = {
         "model": model_name,
         "prompt": prompt,
         "n": 1,
         "size": size,
-    }
-    
-    # Add GPT-Image specific parameters
-    gen_params.update({
         "quality": quality,
         "background": background,
         "output_format": output_format,
-    })
+    }
 
     for attempt in range(max_attempts):
         try:
@@ -648,12 +562,10 @@ async def call_openrouter_with_retry_async(
     max_completion_tokens = config["max_completion_tokens"]
     response_text_list = []
 
-    current_contents = contents
-
     is_input_valid = False
     for attempt in range(max_attempts):
         try:
-            openai_contents = _convert_to_openai_format(current_contents)
+            openai_contents = _convert_to_openai_format(contents)
             first_response = await openrouter_client.chat.completions.create(
                 model=model_name,
                 messages=[
@@ -691,7 +603,7 @@ async def call_openrouter_with_retry_async(
 
     remaining_candidates = candidate_num - 1
     if remaining_candidates > 0:
-        valid_openai_contents = _convert_to_openai_format(current_contents)
+        valid_openai_contents = _convert_to_openai_format(contents)
         tasks = [
             openrouter_client.chat.completions.create(
                 model=model_name,
@@ -864,12 +776,10 @@ async def call_proma_with_retry_async(
     max_completion_tokens = config["max_completion_tokens"]
     response_text_list = []
 
-    current_contents = contents
-
     is_input_valid = False
     for attempt in range(max_attempts):
         try:
-            openai_contents = _convert_to_openai_format(current_contents)
+            openai_contents = _convert_to_openai_format(contents)
             first_response = await proma_client.chat.completions.create(
                 model=model_name,
                 messages=[
@@ -906,7 +816,7 @@ async def call_proma_with_retry_async(
 
     remaining_candidates = candidate_num - 1
     if remaining_candidates > 0:
-        valid_openai_contents = _convert_to_openai_format(current_contents)
+        valid_openai_contents = _convert_to_openai_format(contents)
         tasks = [
             proma_client.chat.completions.create(
                 model=model_name,
@@ -979,12 +889,10 @@ async def call_local_with_retry_async(
     max_completion_tokens = config["max_completion_tokens"]
     response_text_list = []
 
-    current_contents = contents
-
     is_input_valid = False
     for attempt in range(max_attempts):
         try:
-            openai_contents = _convert_to_openai_format(current_contents)
+            openai_contents = _convert_to_openai_format(contents)
             messages = [
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": openai_contents},
@@ -1018,7 +926,7 @@ async def call_local_with_retry_async(
 
     remaining_candidates = candidate_num - 1
     if remaining_candidates > 0:
-        valid_openai_contents = _convert_to_openai_format(current_contents)
+        valid_openai_contents = _convert_to_openai_format(contents)
         messages = [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": valid_openai_contents},

--- a/utils/generation_utils.py
+++ b/utils/generation_utils.py
@@ -57,11 +57,16 @@ proma_client = None
 local_client = None
 
 
-def reinitialize_clients():
+def reinitialize_clients(env_only=False):
     """(Re)build all API clients from current env vars / config file.
 
     Called once at module load and can be called again at runtime
     (e.g. after the user sets new API keys via the Gradio UI).
+
+    Args:
+        env_only: If True, only read from env vars (skip config file fallback).
+                  Use this when called from UI Apply Keys so clearing a key
+                  actually disables the provider.
 
     Returns a list of client names that were successfully initialized.
     """
@@ -69,9 +74,14 @@ def reinitialize_clients():
     global openrouter_client, openrouter_api_key
     global proma_client, local_client
 
+    def _get_key(section, key, env_var):
+        if env_only:
+            return os.getenv(env_var, "")
+        return get_config_val(section, key, env_var, "")
+
     initialized = []
 
-    api_key = get_config_val("api_keys", "google_api_key", "GOOGLE_API_KEY", "")
+    api_key = _get_key("api_keys", "google_api_key", "GOOGLE_API_KEY")
     if api_key:
         gemini_client = genai.Client(api_key=api_key)
         print("Initialized Gemini Client with API Key")
@@ -79,7 +89,7 @@ def reinitialize_clients():
     else:
         gemini_client = None
 
-    key = get_config_val("api_keys", "anthropic_api_key", "ANTHROPIC_API_KEY", "")
+    key = _get_key("api_keys", "anthropic_api_key", "ANTHROPIC_API_KEY")
     if key:
         anthropic_client = AsyncAnthropic(api_key=key)
         print("Initialized Anthropic Client with API Key")
@@ -87,7 +97,7 @@ def reinitialize_clients():
     else:
         anthropic_client = None
 
-    key = get_config_val("api_keys", "openai_api_key", "OPENAI_API_KEY", "")
+    key = _get_key("api_keys", "openai_api_key", "OPENAI_API_KEY")
     if key:
         openai_client = AsyncOpenAI(api_key=key)
         print("Initialized OpenAI Client with API Key")
@@ -95,7 +105,7 @@ def reinitialize_clients():
     else:
         openai_client = None
 
-    openrouter_api_key = get_config_val("api_keys", "openrouter_api_key", "OPENROUTER_API_KEY", "")
+    openrouter_api_key = _get_key("api_keys", "openrouter_api_key", "OPENROUTER_API_KEY")
     if openrouter_api_key:
         openrouter_client = AsyncOpenAI(
             base_url="https://openrouter.ai/api/v1",
@@ -106,7 +116,7 @@ def reinitialize_clients():
     else:
         openrouter_client = None
 
-    key = get_config_val("api_keys", "proma_api_key", "PROMA_API_KEY", "")
+    key = _get_key("api_keys", "proma_api_key", "PROMA_API_KEY")
     if key:
         proma_client = AsyncOpenAI(
             base_url="https://api.proma.cool/v1",
@@ -117,7 +127,7 @@ def reinitialize_clients():
     else:
         proma_client = None
 
-    key = get_config_val("api_keys", "local_api_key", "LOCAL_API_KEY", "")
+    key = _get_key("api_keys", "local_api_key", "LOCAL_API_KEY")
     if key:
         local_client = AsyncOpenAI(
             base_url="http://localhost:3000/api/v1",

--- a/utils/generation_utils.py
+++ b/utils/generation_utils.py
@@ -931,7 +931,11 @@ async def call_proma_with_retry_async(
 
 
 async def _local_stream_collect(client, model_name, messages, temperature, max_completion_tokens):
-    """Collect a full response from a streaming local proxy call."""
+    """Collect a full response from a streaming local proxy call.
+
+    Validates that the stream completed normally (finish_reason == 'stop').
+    Raises RuntimeError on truncated or abnormal stream termination.
+    """
     stream = await client.chat.completions.create(
         model=model_name,
         messages=messages,
@@ -940,10 +944,20 @@ async def _local_stream_collect(client, model_name, messages, temperature, max_c
         stream=True,
     )
     chunks = []
+    finish_reason = None
     async for chunk in stream:
-        if chunk.choices and chunk.choices[0].delta and chunk.choices[0].delta.content:
-            chunks.append(chunk.choices[0].delta.content)
-    return "".join(chunks)
+        if chunk.choices:
+            choice = chunk.choices[0]
+            if choice.delta and choice.delta.content:
+                chunks.append(choice.delta.content)
+            if choice.finish_reason:
+                finish_reason = choice.finish_reason
+    result = "".join(chunks)
+    if finish_reason and finish_reason != "stop":
+        print(f"Warning: Local stream ended with finish_reason={finish_reason} (expected 'stop')")
+    if not result and not finish_reason:
+        raise RuntimeError("Local proxy stream ended without content or finish_reason (likely truncated)")
+    return result
 
 
 async def call_local_with_retry_async(
@@ -1047,10 +1061,15 @@ async def call_model_with_retry_async(
     Unified router that dispatches to the correct provider based on model_name.
 
     Routing rules:
-      1. Explicit prefix overrides: "openrouter/" -> OpenRouter, "claude-" -> Anthropic,
-         "gpt-"/"o1-"/"o3-"/"o4-" -> OpenAI
+      1. Explicit prefix overrides (required for some providers):
+         - "local/"      -> Local proxy (localhost:3000)
+         - "proma/"      -> Proma API
+         - "openrouter/" -> OpenRouter
+         - "claude-"     -> Anthropic
+         - "gpt-"/"o1-"/"o3-"/"o4-" -> OpenAI
       2. No prefix: auto-detect based on which API key is configured.
          Priority: OpenRouter > Gemini > Anthropic > OpenAI
+         Note: Proma and Local require explicit prefixes and do not participate in auto-detect.
     """
     # Explicit provider prefix overrides auto-detection
     if model_name.startswith("local/"):

--- a/utils/generation_utils.py
+++ b/utils/generation_utils.py
@@ -873,10 +873,16 @@ async def _local_stream_collect(client, model_name, messages, temperature, max_c
             if choice.finish_reason:
                 finish_reason = choice.finish_reason
     result = "".join(chunks)
-    if finish_reason and finish_reason != "stop":
-        print(f"Warning: Local stream ended with finish_reason={finish_reason} (expected 'stop')")
-    if not result and not finish_reason:
-        raise RuntimeError("Local proxy stream ended without content or finish_reason (likely truncated)")
+    if finish_reason != "stop":
+        if finish_reason is None:
+            raise RuntimeError(
+                "Local proxy stream ended without finish_reason 'stop' "
+                "(got None; likely truncated or aborted)"
+            )
+        raise RuntimeError(
+            f"Local proxy stream ended with finish_reason={finish_reason!r} "
+            "(expected 'stop')"
+        )
     return result
 
 

--- a/utils/generation_utils.py
+++ b/utils/generation_utils.py
@@ -220,8 +220,9 @@ async def call_gemini_with_retry_async(
             error_str = str(e)
             context_msg = f" for {error_context}" if error_context else ""
 
-            is_region_error = "400" in error_str and "location" in error_str.lower()
-            is_overload_error = "503" in error_str or "UNAVAILABLE" in error_str
+            error_lower = error_str.lower()
+            is_region_error = "400" in error_str and "location" in error_lower
+            is_overload_error = "503" in error_str or "unavailable" in error_lower
             is_image_model = "image" in model_name or "nanoviz" in model_name
 
             # --- 400: Region restriction → abort immediately ---
@@ -290,7 +291,7 @@ async def call_gemini_with_retry_async(
     return result_list
 
 
-# Image model fallback chain: try next available model on 400/503
+# Image model fallback chain: on 503 overload, try next model; on 400 region block, abort immediately
 _IMAGE_MODEL_FALLBACK_CHAIN = [
     "gemini-3.1-flash-image-preview",
     "gemini-3-pro-image-preview",

--- a/utils/generation_utils.py
+++ b/utils/generation_utils.py
@@ -1053,7 +1053,13 @@ async def call_model_with_retry_async(
          Priority: OpenRouter > Gemini > Anthropic > OpenAI
     """
     # Explicit provider prefix overrides auto-detection
-    if model_name.startswith("openrouter/"):
+    if model_name.startswith("local/"):
+        provider = "local"
+        actual_model = model_name[len("local/"):]
+    elif model_name.startswith("proma/"):
+        provider = "proma"
+        actual_model = model_name[len("proma/"):]
+    elif model_name.startswith("openrouter/"):
         provider = "openrouter"
         actual_model = model_name[len("openrouter/"):]
     elif model_name.startswith("claude-"):
@@ -1099,6 +1105,8 @@ async def call_model_with_retry_async(
     }
 
     call_fn = {
+        "local": call_local_with_retry_async,
+        "proma": call_proma_with_retry_async,
         "openrouter": call_openrouter_with_retry_async,
         "anthropic": call_claude_with_retry_async,
         "openai": call_openai_with_retry_async,

--- a/utils/generation_utils.py
+++ b/utils/generation_utils.py
@@ -56,6 +56,8 @@ anthropic_client = None
 openai_client = None
 openrouter_client = None
 openrouter_api_key = ""
+proma_client = None
+local_client = None
 
 
 def reinitialize_clients():
@@ -68,6 +70,7 @@ def reinitialize_clients():
     """
     global gemini_client, anthropic_client, openai_client
     global openrouter_client, openrouter_api_key
+    global proma_client, local_client
 
     initialized = []
 
@@ -105,6 +108,28 @@ def reinitialize_clients():
         initialized.append("OpenRouter")
     else:
         openrouter_client = None
+
+    key = get_config_val("api_keys", "proma_api_key", "PROMA_API_KEY", "")
+    if key:
+        proma_client = AsyncOpenAI(
+            base_url="https://api.proma.cool/v1",
+            api_key=key,
+        )
+        print("Initialized Proma Client with API Key")
+        initialized.append("Proma")
+    else:
+        proma_client = None
+
+    key = get_config_val("api_keys", "local_api_key", "LOCAL_API_KEY", "")
+    if key:
+        local_client = AsyncOpenAI(
+            base_url="http://localhost:3000/api/v1",
+            api_key=key,
+        )
+        print("Initialized Local Proxy Client with API Key")
+        initialized.append("Local")
+    else:
+        local_client = None
 
     return initialized
 
@@ -818,6 +843,91 @@ async def call_openrouter_image_generation_with_retry_async(
                 return ["Error"]
 
     return ["Error"]
+
+
+async def call_proma_with_retry_async(
+    model_name, contents, config, max_attempts=5, retry_delay=10, error_context=""
+):
+    """
+    ASYNC: Call Proma API (OpenAI-compatible) with asynchronous retry logic.
+    """
+    if proma_client is None:
+        raise RuntimeError(
+            "Proma client was not initialized: missing API key. "
+            "Please set PROMA_API_KEY in environment, or configure "
+            "api_keys.proma_api_key in configs/model_config.yaml."
+        )
+
+    system_prompt = config["system_prompt"]
+    temperature = config["temperature"]
+    candidate_num = config["candidate_num"]
+    max_completion_tokens = config["max_completion_tokens"]
+    response_text_list = []
+
+    current_contents = contents
+
+    is_input_valid = False
+    for attempt in range(max_attempts):
+        try:
+            openai_contents = _convert_to_openai_format(current_contents)
+            first_response = await proma_client.chat.completions.create(
+                model=model_name,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": openai_contents},
+                ],
+                temperature=temperature,
+                max_completion_tokens=max_completion_tokens,
+            )
+            content = first_response.choices[0].message.content or ""
+            if not content.strip():
+                print(f"Proma returned empty content, retrying...")
+                if attempt < max_attempts - 1:
+                    await asyncio.sleep(retry_delay)
+                continue
+            response_text_list.append(content)
+            is_input_valid = True
+            break
+
+        except Exception as e:
+            context_msg = f" for {error_context}" if error_context else ""
+            current_delay = min(retry_delay * (2 ** attempt), 60)
+            print(
+                f"Proma attempt {attempt + 1} failed{context_msg}: {e}. "
+                f"Retrying in {current_delay}s..."
+            )
+            if attempt < max_attempts - 1:
+                await asyncio.sleep(current_delay)
+
+    if not is_input_valid:
+        context_msg = f" for {error_context}" if error_context else ""
+        print(f"Error: All {max_attempts} Proma attempts failed{context_msg}.")
+        return ["Error"] * candidate_num
+
+    remaining_candidates = candidate_num - 1
+    if remaining_candidates > 0:
+        valid_openai_contents = _convert_to_openai_format(current_contents)
+        tasks = [
+            proma_client.chat.completions.create(
+                model=model_name,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": valid_openai_contents},
+                ],
+                temperature=temperature,
+                max_completion_tokens=max_completion_tokens,
+            )
+            for _ in range(remaining_candidates)
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for res in results:
+            if isinstance(res, Exception):
+                print(f"Error generating a subsequent Proma candidate: {res}")
+                response_text_list.append("Error")
+            else:
+                response_text_list.append(res.choices[0].message.content or "Error")
+
+    return response_text_list
 
 
 def _to_openrouter_model_id(model_name: str) -> str:

--- a/utils/generation_utils.py
+++ b/utils/generation_utils.py
@@ -930,6 +930,102 @@ async def call_proma_with_retry_async(
     return response_text_list
 
 
+async def _local_stream_collect(client, model_name, messages, temperature, max_completion_tokens):
+    """Collect a full response from a streaming local proxy call."""
+    stream = await client.chat.completions.create(
+        model=model_name,
+        messages=messages,
+        temperature=temperature,
+        max_completion_tokens=max_completion_tokens,
+        stream=True,
+    )
+    chunks = []
+    async for chunk in stream:
+        if chunk.choices and chunk.choices[0].delta and chunk.choices[0].delta.content:
+            chunks.append(chunk.choices[0].delta.content)
+    return "".join(chunks)
+
+
+async def call_local_with_retry_async(
+    model_name, contents, config, max_attempts=5, retry_delay=10, error_context=""
+):
+    """
+    ASYNC: Call local proxy API (OpenAI-compatible, streaming) with asynchronous retry logic.
+    """
+    if local_client is None:
+        raise RuntimeError(
+            "Local proxy client was not initialized: missing API key. "
+            "Please set LOCAL_API_KEY in environment, or configure "
+            "api_keys.local_api_key in configs/model_config.yaml."
+        )
+
+    system_prompt = config["system_prompt"]
+    temperature = config["temperature"]
+    candidate_num = config["candidate_num"]
+    max_completion_tokens = config["max_completion_tokens"]
+    response_text_list = []
+
+    current_contents = contents
+
+    is_input_valid = False
+    for attempt in range(max_attempts):
+        try:
+            openai_contents = _convert_to_openai_format(current_contents)
+            messages = [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": openai_contents},
+            ]
+            content = await _local_stream_collect(
+                local_client, model_name, messages, temperature, max_completion_tokens
+            )
+            if not content.strip():
+                print(f"Local proxy returned empty content, retrying...")
+                if attempt < max_attempts - 1:
+                    await asyncio.sleep(retry_delay)
+                continue
+            response_text_list.append(content)
+            is_input_valid = True
+            break
+
+        except Exception as e:
+            context_msg = f" for {error_context}" if error_context else ""
+            current_delay = min(retry_delay * (2 ** attempt), 60)
+            print(
+                f"Local proxy attempt {attempt + 1} failed{context_msg}: {e}. "
+                f"Retrying in {current_delay}s..."
+            )
+            if attempt < max_attempts - 1:
+                await asyncio.sleep(current_delay)
+
+    if not is_input_valid:
+        context_msg = f" for {error_context}" if error_context else ""
+        print(f"Error: All {max_attempts} Local proxy attempts failed{context_msg}.")
+        return ["Error"] * candidate_num
+
+    remaining_candidates = candidate_num - 1
+    if remaining_candidates > 0:
+        valid_openai_contents = _convert_to_openai_format(current_contents)
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": valid_openai_contents},
+        ]
+        tasks = [
+            _local_stream_collect(
+                local_client, model_name, messages, temperature, max_completion_tokens
+            )
+            for _ in range(remaining_candidates)
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for res in results:
+            if isinstance(res, Exception):
+                print(f"Error generating a subsequent Local proxy candidate: {res}")
+                response_text_list.append("Error")
+            else:
+                response_text_list.append(res if res.strip() else "Error")
+
+    return response_text_list
+
+
 def _to_openrouter_model_id(model_name: str) -> str:
     """Convert a bare model name to OpenRouter format (provider/model).
 

--- a/utils/generation_utils.py
+++ b/utils/generation_utils.py
@@ -142,6 +142,11 @@ def _convert_to_gemini_parts(contents: List[Dict[str, Any]]) -> List[types.Part]
     return gemini_parts
 
 
+class ImageGenerationError(Exception):
+    """Raised when image generation fails irrecoverably (400 region block or all 503 fallbacks exhausted)."""
+    pass
+
+
 async def call_gemini_with_retry_async(
     model_name, contents, config, max_attempts=5, retry_delay=5, error_context=""
 ):
@@ -156,12 +161,15 @@ async def call_gemini_with_retry_async(
 
     result_list = []
     target_candidate_count = config.candidate_count
-    # Gemini API max candidate count is 8. We will call multiple times if needed.
-    if config.candidate_count > 8:
+    # Gemini API max candidate count is 8. Cap without mutating the original config.
+    if target_candidate_count > 8:
+        import copy as _copy
+        config = _copy.copy(config)
         config.candidate_count = 8
 
     current_contents = contents
-    for attempt in range(max_attempts):
+    attempt = 0
+    while attempt < max_attempts:
         try:
             # Use global client
             client = gemini_client
@@ -183,6 +191,7 @@ async def call_gemini_with_retry_async(
                         f"[Warning]: Failed to generate image, retrying in {retry_delay} seconds..."
                     )
                     await asyncio.sleep(retry_delay)
+                    attempt += 1
                     continue
 
                 # In this mode, we can only have one candidate
@@ -208,24 +217,103 @@ async def call_gemini_with_retry_async(
                 break
 
         except Exception as e:
+            error_str = str(e)
             context_msg = f" for {error_context}" if error_context else ""
-            
-            # Exponential backoff (capped at 30s)
+
+            is_region_error = "400" in error_str and "location" in error_str.lower()
+            is_overload_error = "503" in error_str or "UNAVAILABLE" in error_str
+            is_image_model = "image" in model_name or "nanoviz" in model_name
+
+            # --- 400: Region restriction → abort immediately ---
+            if is_region_error and is_image_model:
+                msg = (
+                    f"❌ Model {model_name} blocked by region restriction (400){context_msg}. "
+                    f"Please check your proxy/VPN configuration."
+                )
+                print(msg)
+                fallback_events.append({
+                    "from": model_name, "to": "ABORTED", "reason": "region restriction (400)",
+                })
+                raise ImageGenerationError(msg)
+
+            # --- 503: Overloaded → retry 5 times, then fallback, then abort ---
+            if is_overload_error and is_image_model:
+                if attempt < max_attempts - 1:
+                    current_delay = min(retry_delay * (2 ** attempt), 30)
+                    print(
+                        f"Attempt {attempt + 1} for model {model_name} failed (503){context_msg}. "
+                        f"Retrying in {current_delay} seconds..."
+                    )
+                    await asyncio.sleep(current_delay)
+                    attempt += 1
+                    continue
+                else:
+                    # All retries exhausted for this model, try fallback
+                    fallback = _get_fallback_model(model_name)
+                    if fallback and fallback != model_name:
+                        print(
+                            f"⚠️  Model {model_name} overloaded (503), all {max_attempts} retries failed{context_msg}. "
+                            f"Switching to fallback: {fallback}"
+                        )
+                        fallback_events.append({
+                            "from": model_name, "to": fallback, "reason": "overloaded (503)",
+                        })
+                        model_name = fallback
+                        attempt = 0
+                        continue
+                    else:
+                        # No more fallback models
+                        msg = (
+                            f"❌ All image models exhausted (503){context_msg}. "
+                            f"Last model: {model_name}. All retries and fallbacks failed."
+                        )
+                        print(msg)
+                        fallback_events.append({
+                            "from": model_name, "to": "ABORTED", "reason": "all models exhausted (503)",
+                        })
+                        raise ImageGenerationError(msg)
+
+            # --- Other errors: normal retry with backoff ---
             current_delay = min(retry_delay * (2 ** attempt), 30)
-            
             print(
                 f"Attempt {attempt + 1} for model {model_name} failed{context_msg}: {e}. Retrying in {current_delay} seconds..."
             )
-
             if attempt < max_attempts - 1:
                 await asyncio.sleep(current_delay)
             else:
                 print(f"Error: All {max_attempts} attempts failed{context_msg}")
                 result_list = ["Error"] * target_candidate_count
+        attempt += 1
 
     if len(result_list) < target_candidate_count:
         result_list.extend(["Error"] * (target_candidate_count - len(result_list)))
     return result_list
+
+
+# Image model fallback chain: try next available model on 400/503
+_IMAGE_MODEL_FALLBACK_CHAIN = [
+    "gemini-3.1-flash-image-preview",
+    "gemini-3-pro-image-preview",
+    "gemini-2.5-flash-image",
+]
+
+_fallback_used = {}  # Track which models already fell back to avoid loops
+fallback_events = []  # Collect fallback events for UI display
+
+
+def _get_fallback_model(current_model: str) -> str:
+    """Get the next fallback model in the chain. Returns current model if no fallback available."""
+    if current_model in _fallback_used:
+        return _fallback_used[current_model]
+
+    if current_model in _IMAGE_MODEL_FALLBACK_CHAIN:
+        idx = _IMAGE_MODEL_FALLBACK_CHAIN.index(current_model)
+        for next_idx in range(idx + 1, len(_IMAGE_MODEL_FALLBACK_CHAIN)):
+            fallback = _IMAGE_MODEL_FALLBACK_CHAIN[next_idx]
+            if fallback != current_model:
+                _fallback_used[current_model] = fallback
+                return fallback
+    return current_model
 
 def _convert_to_claude_format(contents: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """

--- a/utils/paperviz_processor.py
+++ b/utils/paperviz_processor.py
@@ -341,7 +341,9 @@ class PaperVizProcessor:
                         data[key] = copy.deepcopy(first_data[key])
             print(f"[Retriever] Done. Retrieved {len(first_data.get('top10_references', []))} references.")
             if tracker:
-                tracker.complete_stage(-1, "Retriever")
+                # Retriever runs once for all candidates; mark all as complete
+                for cid in range(len(data_list)):
+                    tracker.complete_stage(cid, "Retriever")
 
         semaphore = asyncio.Semaphore(max_concurrent)
         async def process_with_semaphore(doc):

--- a/utils/paperviz_processor.py
+++ b/utils/paperviz_processor.py
@@ -22,7 +22,6 @@ import time
 from collections import Counter
 from typing import List, Dict, Any, AsyncGenerator, Callable, Optional
 
-import numpy as np
 from tqdm.asyncio import tqdm
 
 from agents.vanilla_agent import VanillaAgent
@@ -44,7 +43,6 @@ class ProgressTracker:
     def __init__(self, total_candidates: int, stages: List[str], callback: Optional[Callable] = None):
         self.total = total_candidates
         self.stages = stages
-        self.stage_index = {s: i for i, s in enumerate(stages)}
         self.total_steps = len(stages)
         # Per-candidate current stage
         self._candidate_stages: Dict[int, str] = {}
@@ -323,8 +321,15 @@ class PaperVizProcessor:
         retrieval_setting = self.exp_config.retrieval_setting
         needs_retrieval = exp_mode not in ("vanilla", "dev_polish", "dev_retriever")
 
-        # Build stage list for progress tracking
-        stages = self._get_pipeline_stages(exp_mode, data_list[0].get("max_critic_rounds", 3) if data_list else 3)
+        # Build stage list for progress tracking (use max across all candidates)
+        if data_list:
+            batch_max_critic_rounds = max(
+                (data.get("max_critic_rounds", 3) for data in data_list),
+                default=3,
+            )
+        else:
+            batch_max_critic_rounds = 3
+        stages = self._get_pipeline_stages(exp_mode, batch_max_critic_rounds)
         tracker = ProgressTracker(len(data_list), stages, callback=progress_callback) if progress_callback else None
 
         if needs_retrieval and data_list:
@@ -359,7 +364,7 @@ class PaperVizProcessor:
             for future in asyncio.as_completed(tasks):
                 try:
                     result_data = await future
-                except (ImageGenerationError, Exception):
+                except Exception:
                     # Cancel all remaining tasks to avoid wasting API calls
                     for t in tasks:
                         t.cancel()

--- a/utils/paperviz_processor.py
+++ b/utils/paperviz_processor.py
@@ -17,7 +17,10 @@ Processing pipeline of PaperVizAgent
 """
 
 import asyncio
-from typing import List, Dict, Any, AsyncGenerator
+import copy
+import time
+from collections import Counter
+from typing import List, Dict, Any, AsyncGenerator, Callable, Optional
 
 import numpy as np
 from tqdm.asyncio import tqdm
@@ -32,6 +35,66 @@ from agents.polish_agent import PolishAgent
 
 from .config import ExpConfig
 from .eval_toolkits import get_score_for_image_referenced
+from .generation_utils import ImageGenerationError
+
+
+class ProgressTracker:
+    """Tracks pipeline progress across parallel candidates."""
+
+    def __init__(self, total_candidates: int, stages: List[str], callback: Optional[Callable] = None):
+        self.total = total_candidates
+        self.stages = stages
+        self.stage_index = {s: i for i, s in enumerate(stages)}
+        self.total_steps = len(stages)
+        # Per-candidate current stage
+        self._candidate_stages: Dict[int, str] = {}
+        # Per-stage completion count
+        self._stage_done: Dict[str, int] = {s: 0 for s in stages}
+        self._current_stage_start: float = time.time()
+        self._active_stage: str = stages[0] if stages else ""
+        self._active_model: str = ""
+        self._callback = callback
+
+    def enter_stage(self, candidate_id: int, stage: str, model_name: str = ""):
+        """Called when a candidate enters a new pipeline stage."""
+        self._candidate_stages[candidate_id] = stage
+        if model_name:
+            self._active_model = model_name
+        # Update active stage to the most common current stage
+        if self._candidate_stages:
+            most_common = Counter(self._candidate_stages.values()).most_common(1)[0][0]
+            if most_common != self._active_stage:
+                self._active_stage = most_common
+                self._current_stage_start = time.time()
+        self._notify()
+
+    def complete_stage(self, candidate_id: int, stage: str):
+        """Called when a candidate completes a pipeline stage."""
+        if stage in self._stage_done:
+            self._stage_done[stage] += 1
+        self._notify()
+
+    def get_status(self) -> Dict[str, Any]:
+        """Get current progress status for UI display."""
+        elapsed = time.time() - self._current_stage_start
+        # Overall progress: average completion across all candidates
+        total_completed_steps = sum(self._stage_done.values())
+        max_possible = self.total * self.total_steps
+        overall_pct = total_completed_steps / max_possible if max_possible > 0 else 0
+
+        return {
+            "stage": self._active_stage,
+            "model": self._active_model,
+            "elapsed": int(elapsed),
+            "stage_done": self._stage_done.get(self._active_stage, 0),
+            "total": self.total,
+            "overall_pct": min(overall_pct, 1.0),
+            "all_stage_done": dict(self._stage_done),
+        }
+
+    def _notify(self):
+        if self._callback:
+            self._callback(self.get_status())
 
 
 class PaperVizProcessor:
@@ -57,61 +120,107 @@ class PaperVizProcessor:
         self.retriever_agent = retriever_agent
         self.polish_agent = polish_agent
 
-    async def _run_critic_iterations(self, data: Dict[str, Any], task_name: str, max_rounds: int = 3, source: str = "stylist") -> Dict[str, Any]:
+    @staticmethod
+    def _get_pipeline_stages(exp_mode: str, max_critic_rounds: int = 3) -> List[str]:
+        """Return ordered list of stage names for the given pipeline mode."""
+        if exp_mode in ("dev_full", "demo_full"):
+            stages = ["Retriever", "Planner", "Stylist", "Visualizer"]
+        elif exp_mode in ("dev_planner_critic", "demo_planner_critic"):
+            stages = ["Retriever", "Planner", "Visualizer"]
+        elif exp_mode == "dev_planner_stylist":
+            stages = ["Retriever", "Planner", "Stylist", "Visualizer"]
+        elif exp_mode == "dev_planner":
+            stages = ["Retriever", "Planner", "Visualizer"]
+        else:
+            return ["Processing"]
+
+        # Add critic iteration stages
+        if "critic" in exp_mode or "full" in exp_mode:
+            for r in range(max_critic_rounds):
+                stages.append(f"Critic R{r}")
+                stages.append(f"Visualizer (R{r})")
+        return stages
+
+    async def _run_critic_iterations(self, data: Dict[str, Any], task_name: str, max_rounds: int = 3, source: str = "stylist", progress_tracker: Optional[ProgressTracker] = None) -> Dict[str, Any]:
         """
         Run multi-round critic iteration (up to max_rounds).
-        Returns the data with critic suggestions and updated eval_image_field.
-        
-        Args:
-            data: Input data dictionary
-            task_name: Name of the task (e.g., "diagram", "plot")
-            max_rounds: Maximum number of critic iterations
-            source: Source of the input for round 0 critique ("stylist" or "planner")
         """
-        # Determine initial fallback image key based on source
+        cid = data.get("candidate_id", 0)
         if source == "planner":
             current_best_image_key = f"target_{task_name}_desc0_base64_jpg"
-        else: # default to stylist
+        else:
             current_best_image_key = f"target_{task_name}_stylist_desc0_base64_jpg"
-            
+
+        round_idx = -1
         for round_idx in range(max_rounds):
+            stage_name = f"Critic R{round_idx}"
+            if progress_tracker:
+                progress_tracker.enter_stage(cid, stage_name, self.exp_config.main_model_name)
+
             data["current_critic_round"] = round_idx
             data = await self.critic_agent.process(data, source=source)
-            
+
+            if progress_tracker:
+                progress_tracker.complete_stage(cid, stage_name)
+
             critic_suggestions_key = f"target_{task_name}_critic_suggestions{round_idx}"
             critic_suggestions = data.get(critic_suggestions_key, "")
-            
+
             if critic_suggestions.strip() == "No changes needed.":
                 print(f"[Critic Round {round_idx}] No changes needed. Stopping iteration.")
+                # Mark skipped Visualizer for this round
+                if progress_tracker:
+                    progress_tracker.complete_stage(cid, f"Visualizer (R{round_idx})")
                 break
-            
+
+            viz_stage = f"Visualizer (R{round_idx})"
+            if progress_tracker:
+                progress_tracker.enter_stage(cid, viz_stage, self.exp_config.image_gen_model_name)
+
             data = await self.visualizer_agent.process(data)
-            
-            # Check if visualization validation succeeded
+
+            if progress_tracker:
+                progress_tracker.complete_stage(cid, viz_stage)
+
             new_image_key = f"target_{task_name}_critic_desc{round_idx}_base64_jpg"
             if new_image_key in data and data[new_image_key]:
                 current_best_image_key = new_image_key
                 print(f"[Critic Round {round_idx}] Completed iteration. Visualization SUCCESS.")
             else:
                 print(f"[Critic Round {round_idx}] Visualization FAILED (No valid image). Rolling back to previous best: {current_best_image_key}")
-                break
-        
+                break  # remaining stages filled below
+
+        # Mark remaining skipped stages as complete so progress bar reaches 100%
+        if progress_tracker:
+            last_completed = round_idx
+            for remaining in range(last_completed + 1, max_rounds):
+                progress_tracker.complete_stage(cid, f"Critic R{remaining}")
+                progress_tracker.complete_stage(cid, f"Visualizer (R{remaining})")
+
         data["eval_image_field"] = current_best_image_key
         return data
 
     async def process_single_query(
-        self, data: Dict[str, Any], do_eval=True
+        self, data: Dict[str, Any], do_eval=True, progress_tracker: Optional[ProgressTracker] = None
     ) -> Dict[str, Any]:
         """
         Complete processing pipeline for a single query
         """
-        # print(f"[DEBUG] -> Entered process_single_query for candidate {data.get('candidate_id', 'N/A')}")
         exp_mode = self.exp_config.exp_mode
         task_name = self.exp_config.task_name.lower()
         retrieval_setting = self.exp_config.retrieval_setting
+        cid = data.get("candidate_id", 0)
 
         # Skip retriever if results were already populated by process_queries_batch
         already_retrieved = "top10_references" in data
+
+        def _enter(stage, model=""):
+            if progress_tracker:
+                progress_tracker.enter_stage(cid, stage, model)
+
+        def _done(stage):
+            if progress_tracker:
+                progress_tracker.complete_stage(cid, stage)
 
         if exp_mode == "vanilla":
             data = await self.vanilla_agent.process(data)
@@ -120,43 +229,73 @@ class PaperVizProcessor:
         elif exp_mode == "dev_planner":
             if not already_retrieved:
                 data = await self.retriever_agent.process(data, retrieval_setting=retrieval_setting)
+            _enter("Planner", self.exp_config.main_model_name)
             data = await self.planner_agent.process(data)
+            _done("Planner")
+            _enter("Visualizer", self.exp_config.image_gen_model_name)
             data = await self.visualizer_agent.process(data)
+            _done("Visualizer")
             data["eval_image_field"] = f"target_{task_name}_desc0_base64_jpg"
 
         elif exp_mode == "dev_planner_stylist":
             if not already_retrieved:
                 data = await self.retriever_agent.process(data, retrieval_setting=retrieval_setting)
+            _enter("Planner", self.exp_config.main_model_name)
             data = await self.planner_agent.process(data)
+            _done("Planner")
+            _enter("Stylist", self.exp_config.main_model_name)
             data = await self.stylist_agent.process(data)
+            _done("Stylist")
+            _enter("Visualizer", self.exp_config.image_gen_model_name)
             data = await self.visualizer_agent.process(data)
+            _done("Visualizer")
             data["eval_image_field"] = f"target_{task_name}_stylist_desc0_base64_jpg"
 
         elif exp_mode in ["dev_planner_critic", "demo_planner_critic"]:
             if not already_retrieved:
                 data = await self.retriever_agent.process(data, retrieval_setting=retrieval_setting)
+            _enter("Planner", self.exp_config.main_model_name)
             data = await self.planner_agent.process(data)
+            _done("Planner")
+            _enter("Visualizer", self.exp_config.image_gen_model_name)
             data = await self.visualizer_agent.process(data)
-            # Use max_critic_rounds from data if available, otherwise default to 3
+            _done("Visualizer")
+            image_key = f"target_{task_name}_desc0_base64_jpg"
+            if not (image_key in data and data[image_key] and data[image_key] != "Error"):
+                raise ImageGenerationError(
+                    f"❌ Visualizer failed for candidate {cid}. Image generation returned no valid result. "
+                    f"Terminating to avoid wasting API costs on Critic iterations."
+                )
             max_rounds = data.get("max_critic_rounds", 3)
-            data = await self._run_critic_iterations(data, task_name, max_rounds=max_rounds, source="planner")
+            data = await self._run_critic_iterations(data, task_name, max_rounds=max_rounds, source="planner", progress_tracker=progress_tracker)
             if "demo" in exp_mode: do_eval = False
 
         elif exp_mode in ["dev_full", "demo_full"]:
             if not already_retrieved:
                 data = await self.retriever_agent.process(data, retrieval_setting=retrieval_setting)
+            _enter("Planner", self.exp_config.main_model_name)
             data = await self.planner_agent.process(data)
+            _done("Planner")
+            _enter("Stylist", self.exp_config.main_model_name)
             data = await self.stylist_agent.process(data)
+            _done("Stylist")
+            _enter("Visualizer", self.exp_config.image_gen_model_name)
             data = await self.visualizer_agent.process(data)
-            # Use max_critic_rounds from data (if set) or config
+            _done("Visualizer")
+            image_key = f"target_{task_name}_stylist_desc0_base64_jpg"
+            if not (image_key in data and data[image_key] and data[image_key] != "Error"):
+                raise ImageGenerationError(
+                    f"❌ Visualizer failed for candidate {cid}. Image generation returned no valid result. "
+                    f"Terminating to avoid wasting API costs on Critic iterations."
+                )
             max_rounds = data.get("max_critic_rounds", self.exp_config.max_critic_rounds)
-            data = await self._run_critic_iterations(data, task_name, max_rounds=max_rounds, source="stylist")
+            data = await self._run_critic_iterations(data, task_name, max_rounds=max_rounds, source="stylist", progress_tracker=progress_tracker)
             if "demo" in exp_mode: do_eval = False
-        
+
         elif exp_mode == "dev_polish":
             data = await self.polish_agent.process(data)
             data["eval_image_field"] = f"polished_{task_name}_base64_jpg"
-        
+
         elif exp_mode == "dev_retriever":
             data = await self.retriever_agent.process(data)
             do_eval = False
@@ -175,17 +314,23 @@ class PaperVizProcessor:
         data_list: List[Dict[str, Any]],
         max_concurrent: int = 50,
         do_eval: bool = True,
+        progress_callback: Optional[Callable] = None,
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """
         Batch process queries with concurrency support.
         Retriever is run once before parallelization to avoid redundant API calls.
         """
-        # Run Retriever once and share results across all candidates
         exp_mode = self.exp_config.exp_mode
         retrieval_setting = self.exp_config.retrieval_setting
         needs_retrieval = exp_mode not in ("vanilla", "dev_polish", "dev_retriever")
 
+        # Build stage list for progress tracking
+        stages = self._get_pipeline_stages(exp_mode, data_list[0].get("max_critic_rounds", 3) if data_list else 3)
+        tracker = ProgressTracker(len(data_list), stages, callback=progress_callback) if progress_callback else None
+
         if needs_retrieval and data_list:
+            if tracker:
+                tracker.enter_stage(-1, "Retriever", self.exp_config.main_model_name)
             print("[Retriever] Running retrieval once for all candidates...")
             first_data = data_list[0]
             first_data = await self.retriever_agent.process(first_data, retrieval_setting=retrieval_setting)
@@ -193,27 +338,37 @@ class PaperVizProcessor:
             for data in data_list[1:]:
                 for key in retrieval_keys:
                     if key in first_data:
-                        data[key] = first_data[key]
+                        data[key] = copy.deepcopy(first_data[key])
             print(f"[Retriever] Done. Retrieved {len(first_data.get('top10_references', []))} references.")
+            if tracker:
+                tracker.complete_stage(-1, "Retriever")
 
         semaphore = asyncio.Semaphore(max_concurrent)
         async def process_with_semaphore(doc):
             async with semaphore:
-                return await self.process_single_query(doc, do_eval=do_eval)
+                return await self.process_single_query(doc, do_eval=do_eval, progress_tracker=tracker)
 
         # Create all tasks
         tasks = []
         for data in data_list:
             task = asyncio.create_task(process_with_semaphore(data))
             tasks.append(task)
-        
+
         all_result_list = []
         eval_dims = ["faithfulness", "conciseness", "readability", "aesthetics", "overall"]
 
         with tqdm(total=len(tasks), desc="Processing concurrently",ascii=True) as pbar:
             # Iterate through completed tasks returned by as_completed
             for future in asyncio.as_completed(tasks):
-                result_data = await future
+                try:
+                    result_data = await future
+                except (ImageGenerationError, Exception):
+                    # Cancel all remaining tasks to avoid wasting API calls
+                    for t in tasks:
+                        t.cancel()
+                    # Await cancelled tasks to suppress asyncio warnings
+                    await asyncio.gather(*tasks, return_exceptions=True)
+                    raise
                 all_result_list.append(result_data)
                 postfix_dict = {}
 

--- a/utils/paperviz_processor.py
+++ b/utils/paperviz_processor.py
@@ -123,18 +123,13 @@ class PaperVizProcessor:
     @staticmethod
     def _get_pipeline_stages(exp_mode: str, max_critic_rounds: int = 3) -> List[str]:
         """Return ordered list of stage names for the given pipeline mode."""
-        if exp_mode in ("dev_full", "demo_full"):
+        if exp_mode in ("dev_full", "demo_full", "dev_planner_stylist"):
             stages = ["Retriever", "Planner", "Stylist", "Visualizer"]
-        elif exp_mode in ("dev_planner_critic", "demo_planner_critic"):
-            stages = ["Retriever", "Planner", "Visualizer"]
-        elif exp_mode == "dev_planner_stylist":
-            stages = ["Retriever", "Planner", "Stylist", "Visualizer"]
-        elif exp_mode == "dev_planner":
+        elif exp_mode in ("dev_planner_critic", "demo_planner_critic", "dev_planner"):
             stages = ["Retriever", "Planner", "Visualizer"]
         else:
             return ["Processing"]
 
-        # Add critic iteration stages
         if "critic" in exp_mode or "full" in exp_mode:
             for r in range(max_critic_rounds):
                 stages.append(f"Critic R{r}")
@@ -304,10 +299,8 @@ class PaperVizProcessor:
             raise ValueError(f"Unknown experiment name: {exp_mode}")
 
         if do_eval:
-            data_with_eval = await self.evaluation_function(data, exp_config=self.exp_config)
-            return data_with_eval
-        else:
-            return data
+            return await self.evaluation_function(data, exp_config=self.exp_config)
+        return data
 
     async def process_queries_batch(
         self,
@@ -350,11 +343,7 @@ class PaperVizProcessor:
             async with semaphore:
                 return await self.process_single_query(doc, do_eval=do_eval, progress_tracker=tracker)
 
-        # Create all tasks
-        tasks = []
-        for data in data_list:
-            task = asyncio.create_task(process_with_semaphore(data))
-            tasks.append(task)
+        tasks = [asyncio.create_task(process_with_semaphore(data)) for data in data_list]
 
         all_result_list = []
         eval_dims = ["faithfulness", "conciseness", "readability", "aesthetics", "overall"]

--- a/utils/paperviz_processor.py
+++ b/utils/paperviz_processor.py
@@ -218,7 +218,9 @@ class PaperVizProcessor:
                 progress_tracker.complete_stage(cid, stage)
 
         if exp_mode == "vanilla":
+            _enter("Processing")
             data = await self.vanilla_agent.process(data)
+            _done("Processing")
             data["eval_image_field"] = f"vanilla_{task_name}_base64_jpg"
 
         elif exp_mode == "dev_planner":
@@ -288,11 +290,15 @@ class PaperVizProcessor:
             if "demo" in exp_mode: do_eval = False
 
         elif exp_mode == "dev_polish":
+            _enter("Processing")
             data = await self.polish_agent.process(data)
+            _done("Processing")
             data["eval_image_field"] = f"polished_{task_name}_base64_jpg"
 
         elif exp_mode == "dev_retriever":
+            _enter("Processing")
             data = await self.retriever_agent.process(data)
+            _done("Processing")
             do_eval = False
 
         else:
@@ -323,7 +329,7 @@ class PaperVizProcessor:
 
         if needs_retrieval and data_list:
             if tracker:
-                tracker.enter_stage(-1, "Retriever", self.exp_config.main_model_name)
+                tracker.enter_stage(0, "Retriever", self.exp_config.main_model_name)
             print("[Retriever] Running retrieval once for all candidates...")
             first_data = data_list[0]
             first_data = await self.retriever_agent.process(first_data, retrieval_setting=retrieval_setting)


### PR DESCRIPTION
## Summary

- **Multi-provider support**: Add Proma and Local proxy API providers with routing (`proma/`, `local/` prefixes), alongside existing Gemini/OpenRouter/Anthropic/OpenAI. `reinitialize_clients(env_only=True)` allows UI to fully control provider state.
- **Gradio UI enhancements**: Model/font selection dropdowns with presets (`allow_custom_value`), mock mode for UI testing, real-time progress bar via ProgressTracker, preflight image model check with 503 fallback chain
- **Error handling**: `ImageGenerationError` for 400 region block / 503 overload, automatic fallback chain (flash → pro → legacy), early abort to prevent wasted Critic API costs
- **Font injection**: Chinese/English font constraints injected into Visualizer prompt (gated to image generation only, skips plot code-gen)
- **Bug fixes**: deepcopy for shared `additional_info`, RGBA→RGB in Refine tab, dynamic critic round limits, `apply_keys()` env_only mode, ProgressTracker sentinel cleanup
- **Code quality**: project-wide simplification (-117 lines), `_run_async()` helper, dead code removal, `_local_stream_collect` strict finish_reason validation
- **Tooling**: `scripts/fix_text.py` — OCR text correction tool (macOS Vision + LLM, graceful error on non-macOS)
- **Security**: Hardened `.gitignore` with `.env` / `*.env` / `configs/*.local.yaml` / `configs/secrets*.yaml` patterns

## Test plan

- [ ] Start Gradio UI (`python app.py`) and verify all settings render correctly
- [ ] Test model dropdown selection and custom input
- [ ] Test Mock Mode (no API calls, simulated delays, progress bar updates)
- [ ] Generate candidates with `demo_planner_critic` and `demo_full` pipelines
- [ ] Verify progress bar updates during generation (including vanilla/polish modes)
- [ ] Test Refine tab with PNG (transparent) and JPEG uploads
- [ ] Test Apply Keys: set and clear API keys, verify provider activation/deactivation
- [ ] Verify preflight skips when OpenRouter is configured
- [ ] Run `python scripts/fix_text.py --help` (macOS) and verify graceful error on other platforms
- [ ] Verify font injection only applies to image generation, not plot code-gen
