### PR TITLE
fix(critic): coerce non-string critic_suggestions before .strip()

### DIFF
--- a/utils/paperviz_processor.py
+++ b/utils/paperviz_processor.py
@@ -80,7 +80,14 @@ class PaperVizProcessor:
             
             critic_suggestions_key = f"target_{task_name}_critic_suggestions{round_idx}"
             critic_suggestions = data.get(critic_suggestions_key, "")
-            
+            # Critic output occasionally parses to NaN (float) or None when the
+            # model returns empty/malformed JSON on dense content. Coerce to str
+            # before calling .strip() to avoid AttributeError mid-run.
+            if not isinstance(critic_suggestions, str):
+                critic_suggestions = "" if critic_suggestions is None or (
+                    isinstance(critic_suggestions, float) and str(critic_suggestions) == "nan"
+                ) else str(critic_suggestions)
+
             if critic_suggestions.strip() == "No changes needed.":
                 print(f"[Critic Round {round_idx}] No changes needed. Stopping iteration.")
                 break


### PR DESCRIPTION
## Summary

The critic agent occasionally returns `NaN` (float) or `None` as `target_<task>_critic_suggestions<round>` when the underlying model response is empty or malformed JSON. On the affected round, `_run_critic_iterations` (`utils/paperviz_processor.py:84`) crashes:

```
AttributeError: 'float' object has no attribute 'strip'
```

…aborting the run after ~1–2 minutes and discarding any candidates already processed through earlier rounds. Most reliably hit on long, numeric-dense content with multiple threshold inequalities in one spec.

## Fix

One-line defensive coerce before calling `.strip()`: map `None` and `NaN` to `""` (semantically "no suggestion this round" — equivalent to the normal empty-string return), otherwise `str(...)`.

```python
critic_suggestions = data.get(critic_suggestions_key, "")
if not isinstance(critic_suggestions, str):
    critic_suggestions = "" if critic_suggestions is None or (
        isinstance(critic_suggestions, float) and str(critic_suggestions) == "nan"
    ) else str(critic_suggestions)
```

No behaviour change on the happy path (string returns pass through untouched). On the crashing path, the loop proceeds to the visualizer with the prior image as-is.

## Repro

```bash
python skill/run.py \
  --content-file long_numeric_spec.txt \
  --caption "..." \
  --task diagram \
  --num-candidates 2
```

…where `long_numeric_spec.txt` contains ≥4 threshold inequalities (e.g. `γ = 0.85`, `‖ε‖ > θ_conflict = 3.0`, `w ≥ θ_retrieval = 0.35`) inside a prose block >2k chars. Hits the bug on ~1 in 8 runs in my testing. After the patch, the same input runs to completion through all critic rounds.

## Test plan

- [x] Re-ran the exact failing input after the patch — completed normally through r0 → r1 → r2 on both candidates.
- [x] Ran 6 unaffected figures (varied content lengths, aspect ratios) — no regression.
- [ ] Maintainer to verify: no production runs relied on the crash to detect a malformed critic response (I don't see any such callers, but flagging for review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)