### PR TITLE
Remove hosted UI credential mutation path

### DIFF
--- a/app.py
+++ b/app.py
@@ -489,38 +489,18 @@ def build_app():
         # API KEYS ACCORDION
         # ================================================================
         with gr.Accordion("API Keys", open=False):
+            openrouter_configured = bool(get_config_val("api_keys", "openrouter_api_key", "OPENROUTER_API_KEY", ""))
+            google_configured = bool(get_config_val("api_keys", "google_api_key", "GOOGLE_API_KEY", ""))
+            openrouter_status = "configured" if openrouter_configured else "not configured"
+            google_status = "configured" if google_configured else "not configured"
             gr.Markdown(
-                "**You do not need both keys.** Fill **at least one**: **OpenRouter** *or* **Google (Gemini)**. "
-                "If both are set, OpenRouter is preferred for automatic routing when available."
+                "**Credentials are loaded at server startup only.** Configure `OPENROUTER_API_KEY` "
+                "or `GOOGLE_API_KEY` in the environment, or set them in `configs/model_config.yaml` "
+                "before launching PaperBanana. If both are set, OpenRouter is preferred for automatic "
+                "routing when available.\n\n"
+                f"- OpenRouter: **{openrouter_status}**\n"
+                f"- Google Gemini: **{google_status}**"
             )
-            with gr.Row():
-                openrouter_key_input = gr.Textbox(
-                    label="OpenRouter API Key (optional)", type="password", placeholder="sk-or-...",
-                    value=get_config_val("api_keys", "openrouter_api_key", "OPENROUTER_API_KEY", ""),
-                )
-                google_key_input = gr.Textbox(
-                    label="Google API Key (optional)", type="password", placeholder="AIza...",
-                    value=get_config_val("api_keys", "google_api_key", "GOOGLE_API_KEY", ""),
-                )
-            gr.Markdown("*Keys are used only for this session and never stored.*")
-
-            def apply_keys(or_key, g_key):
-                if or_key:
-                    os.environ["OPENROUTER_API_KEY"] = or_key
-                if g_key:
-                    os.environ["GOOGLE_API_KEY"] = g_key
-                from utils.generation_utils import reinitialize_clients
-                initialized = reinitialize_clients()
-                if initialized:
-                    return f"Clients initialized: {', '.join(initialized)}."
-                return (
-                    "Warning: no API clients could be initialized. "
-                    "Enter at least one key—OpenRouter or Google (Gemini)."
-                )
-
-            apply_keys_btn = gr.Button("Apply Keys", size="sm")
-            keys_status = gr.Textbox(visible=False)
-            apply_keys_btn.click(apply_keys, inputs=[openrouter_key_input, google_key_input], outputs=[keys_status])
 
         # ================================================================
         # TABS

--- a/tests/test_app_credential_isolation.py
+++ b/tests/test_app_credential_isolation.py
@@ -1,0 +1,141 @@
+import ast
+from pathlib import Path
+import unittest
+
+
+APP_PATH = Path(__file__).resolve().parents[1] / "app.py"
+CREDENTIAL_ENV_VARS = {"GOOGLE_API_KEY", "OPENROUTER_API_KEY"}
+
+
+class AppCredentialIsolationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.source = APP_PATH.read_text(encoding="utf-8")
+        cls.tree = ast.parse(cls.source, filename=str(APP_PATH))
+
+    def test_app_does_not_assign_api_keys_to_os_environ(self):
+        writes = []
+
+        for node in ast.walk(self.tree):
+            if isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
+                targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+                for target in targets:
+                    env_var = self._os_environ_subscript_key(target)
+                    if env_var in CREDENTIAL_ENV_VARS:
+                        writes.append((env_var, node.lineno))
+
+        self.assertEqual([], writes)
+
+    def test_app_does_not_mutate_api_keys_through_os_calls(self):
+        mutations = []
+
+        for node in ast.walk(self.tree):
+            if not isinstance(node, ast.Call):
+                continue
+
+            if self._is_os_putenv_call(node) and self._first_constant_arg(node) in CREDENTIAL_ENV_VARS:
+                mutations.append(("os.putenv", node.lineno))
+
+            if self._is_os_environ_setitem_call(node) and self._first_constant_arg(node) in CREDENTIAL_ENV_VARS:
+                mutations.append(("os.environ.__setitem__", node.lineno))
+
+        self.assertEqual([], mutations)
+
+    def test_no_apply_keys_callback_remains(self):
+        function_names = {
+            node.name
+            for node in ast.walk(self.tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+        self.assertNotIn("apply_keys", function_names)
+        self.assertNotIn("Apply Keys", self._string_constants())
+
+        click_bindings = []
+        for node in ast.walk(self.tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Attribute) or node.func.attr != "click":
+                continue
+            if node.args and isinstance(node.args[0], ast.Name) and node.args[0].id == "apply_keys":
+                click_bindings.append(node.lineno)
+
+        self.assertEqual([], click_bindings)
+
+    def test_no_api_key_password_textboxes_remain(self):
+        key_textboxes = []
+
+        for node in ast.walk(self.tree):
+            if not isinstance(node, ast.Call) or not self._is_gradio_constructor(node, "Textbox"):
+                continue
+            keywords = {keyword.arg: keyword.value for keyword in node.keywords}
+            textbox_type = self._constant_value(keywords.get("type"))
+            label = self._constant_value(keywords.get("label"))
+            if textbox_type == "password" and isinstance(label, str) and "API Key" in label:
+                key_textboxes.append((label, node.lineno))
+
+        self.assertEqual([], key_textboxes)
+
+    def _string_constants(self):
+        return {
+            node.value
+            for node in ast.walk(self.tree)
+            if isinstance(node, ast.Constant) and isinstance(node.value, str)
+        }
+
+    @staticmethod
+    def _constant_value(node):
+        if isinstance(node, ast.Constant):
+            return node.value
+        return None
+
+    @classmethod
+    def _first_constant_arg(cls, node):
+        if not node.args:
+            return None
+        return cls._constant_value(node.args[0])
+
+    @staticmethod
+    def _is_gradio_constructor(node, name):
+        return (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "gr"
+            and node.func.attr == name
+        )
+
+    @classmethod
+    def _os_environ_subscript_key(cls, target):
+        if not isinstance(target, ast.Subscript):
+            return None
+        if not (
+            isinstance(target.value, ast.Attribute)
+            and isinstance(target.value.value, ast.Name)
+            and target.value.value.id == "os"
+            and target.value.attr == "environ"
+        ):
+            return None
+        return cls._constant_value(target.slice)
+
+    @staticmethod
+    def _is_os_putenv_call(node):
+        return (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "os"
+            and node.func.attr == "putenv"
+        )
+
+    @staticmethod
+    def _is_os_environ_setitem_call(node):
+        return (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "__setitem__"
+            and isinstance(node.func.value, ast.Attribute)
+            and isinstance(node.func.value.value, ast.Name)
+            and node.func.value.value.id == "os"
+            and node.func.value.attr == "environ"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- remove Gradio API-key textboxes and the Apply Keys callback that wrote user-provided keys into process-global environment variables
- keep startup/config based credential loading and show configured/not-configured status in the UI
- add static guardrail tests proving `app.py` does not assign `GOOGLE_API_KEY` or `OPENROUTER_API_KEY` through UI code paths

Fixes #61.

## Validation
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. /Users/jeff/Codex_projects/PaperBanana/.venv/bin/python -m unittest tests.test_app_credential_isolation
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. /Users/jeff/Codex_projects/PaperBanana/.venv/bin/python -m pytest -q -p no:cacheprovider tests
- git diff origin/main --check