### PR TITLE
Add opt-in planner metaphor mode

### DIFF
--- a/agents/planner_agent.py
+++ b/agents/planner_agent.py
@@ -35,14 +35,20 @@ class PlannerAgent(BaseAgent):
 
         # Task-specific configurations
         if "plot" in self.exp_config.task_name:
-            self.system_prompt = PLOT_PLANNER_AGENT_SYSTEM_PROMPT
+            self.system_prompt = build_planner_system_prompt(
+                task_name="plot",
+                planner_metaphor=self.exp_config.planner_metaphor,
+            )
             self.task_config = {
                 "task_name": "plot",
                 "content_label": "Plot Raw Data",
                 "visual_intent_label": "Visual Intent of the Desired Plot",
             }
         else:
-            self.system_prompt = DIAGRAM_PLANNER_AGENT_SYSTEM_PROMPT
+            self.system_prompt = build_planner_system_prompt(
+                task_name="diagram",
+                planner_metaphor=self.exp_config.planner_metaphor,
+            )
             self.task_config = {
                 "task_name": "diagram",
                 "content_label": "Methodology Section",
@@ -122,6 +128,15 @@ class PlannerAgent(BaseAgent):
 
 
 
+def build_planner_system_prompt(task_name: str, planner_metaphor: bool = False) -> str:
+    """Return the Planner system prompt, preserving defaults byte-for-byte."""
+    if "plot" in task_name:
+        return PLOT_PLANNER_AGENT_SYSTEM_PROMPT
+    if planner_metaphor:
+        return DIAGRAM_PLANNER_AGENT_SYSTEM_PROMPT + DIAGRAM_PLANNER_METAPHOR_SUPPLEMENT
+    return DIAGRAM_PLANNER_AGENT_SYSTEM_PROMPT
+
+
 DIAGRAM_PLANNER_AGENT_SYSTEM_PROMPT = """
 I am working on a task: given the 'Methodology' section of a paper, and the caption of the desired figure, automatically generate a corresponding illustrative diagram. I will input the text of the 'Methodology' section, the figure caption, and your output should be a detailed description of an illustrative figure that effectively represents the methods described in the text.
 
@@ -129,6 +144,13 @@ To help you understand the task better, and grasp the principles for generating 
 
 ** IMPORTANT: **
 Your description should be as detailed as possible. Semantically, clearly describe each element and their connections. Formally, include various details such as background style (typically pure white or very light pastel), colors, line thickness, icon styles, etc. Remember: vague or unclear specifications will only make the generated figure worse, not better.
+"""
+
+DIAGRAM_PLANNER_METAPHOR_SUPPLEMENT = """
+
+Planner metaphor mode (diagram-only): Before producing the detailed description, identify a compact visual metaphor that can organize the diagram's layout and relationships, such as a pipeline, map, layered stack, control loop, branching tree, or hub-and-spoke network. Use the metaphor only as a conceptual guide for the diagram composition.
+
+Return the same detailed textual figure-description output requested above. Do not output SVG, code, image markup, a separate sketch, or rendering instructions beyond the detailed description.
 """
 
 PLOT_PLANNER_AGENT_SYSTEM_PROMPT = """
@@ -139,4 +161,3 @@ To help you understand the task better, and grasp the principles for generating 
 ** IMPORTANT: **
 Your description should be as detailed as possible. For content, explain the precise mapping of variables to visual channels (x, y, hue) and explicitly enumerate every raw data point's coordinate to be drawn to ensure accuracy. For presentation, specify the exact aesthetic parameters, including specific HEX color codes, font sizes for all labels, line widths, marker dimensions, legend placement, and grid styles. You should learn from the examples' content presentation and aesthetic design (e.g., color schemes).
 """
-

--- a/main.py
+++ b/main.py
@@ -71,6 +71,11 @@ async def main():
         help="retrieval setting for planner agent (default: auto)",
     )
     parser.add_argument(
+        "--planner-metaphor",
+        action="store_true",
+        help="enable diagram-only Planner visual-metaphor discovery before detailed description output",
+    )
+    parser.add_argument(
         "--max_critic_rounds",
         type=int,
         default=3,
@@ -96,6 +101,7 @@ async def main():
         split_name=args.split_name,
         exp_mode=args.exp_mode,
         retrieval_setting=args.retrieval_setting,
+        planner_metaphor=args.planner_metaphor,
         max_critic_rounds=args.max_critic_rounds,
         main_model_name=args.main_model_name,
         image_gen_model_name=args.image_gen_model_name,

--- a/skill/run.py
+++ b/skill/run.py
@@ -111,6 +111,7 @@ async def run(args):
         split_name="demo",
         exp_mode=exp_mode,
         retrieval_setting=args.retrieval_setting,
+        planner_metaphor=args.planner_metaphor,
         main_model_name=args.main_model_name,
         image_gen_model_name=args.image_gen_model_name,
         work_dir=PROJECT_ROOT,
@@ -209,6 +210,8 @@ def main():
     parser.add_argument("--retrieval-setting", type=str, default="auto",
                         choices=["auto", "manual", "random", "none"],
                         help="Retrieval mode: auto (VLM selects refs), manual, random, or none (default: auto)")
+    parser.add_argument("--planner-metaphor", action="store_true",
+                        help="Enable diagram-only Planner visual-metaphor discovery before detailed description output")
     parser.add_argument("--main-model-name", type=str, default="",
                         help="Main model name for VLM agents (default: from config, currently gemini-3.1-pro-preview)")
     parser.add_argument("--image-gen-model-name", type=str, default="",

--- a/tests/test_planner_metaphor.py
+++ b/tests/test_planner_metaphor.py
@@ -1,0 +1,97 @@
+from pathlib import Path
+
+from agents.planner_agent import (
+    DIAGRAM_PLANNER_AGENT_SYSTEM_PROMPT,
+    DIAGRAM_PLANNER_METAPHOR_SUPPLEMENT,
+    PLOT_PLANNER_AGENT_SYSTEM_PROMPT,
+    PlannerAgent,
+    build_planner_system_prompt,
+)
+from utils.config import ExpConfig
+
+
+def test_exp_config_planner_metaphor_defaults_false(tmp_path):
+    exp_config = ExpConfig(
+        dataset_name="PaperBananaBench",
+        task_name="diagram",
+        work_dir=Path(tmp_path),
+        main_model_name="test-main",
+        image_gen_model_name="test-image",
+    )
+
+    assert exp_config.planner_metaphor is False
+
+
+def test_default_diagram_planner_prompt_is_unchanged():
+    assert (
+        build_planner_system_prompt(task_name="diagram")
+        == DIAGRAM_PLANNER_AGENT_SYSTEM_PROMPT
+    )
+    assert "Planner metaphor mode" not in build_planner_system_prompt(task_name="diagram")
+
+
+def test_metaphor_supplement_only_when_enabled_for_diagrams():
+    default_prompt = build_planner_system_prompt(
+        task_name="diagram",
+        planner_metaphor=False,
+    )
+    metaphor_prompt = build_planner_system_prompt(
+        task_name="diagram",
+        planner_metaphor=True,
+    )
+
+    assert default_prompt == DIAGRAM_PLANNER_AGENT_SYSTEM_PROMPT
+    assert metaphor_prompt == (
+        DIAGRAM_PLANNER_AGENT_SYSTEM_PROMPT + DIAGRAM_PLANNER_METAPHOR_SUPPLEMENT
+    )
+    assert "Planner metaphor mode (diagram-only)" in metaphor_prompt
+    assert "Before producing the detailed description" in metaphor_prompt
+
+
+def test_planner_metaphor_is_diagram_only_and_keeps_description_output():
+    plot_prompt = build_planner_system_prompt(
+        task_name="plot",
+        planner_metaphor=True,
+    )
+    diagram_prompt = build_planner_system_prompt(
+        task_name="diagram",
+        planner_metaphor=True,
+    )
+
+    assert plot_prompt == PLOT_PLANNER_AGENT_SYSTEM_PROMPT
+    assert "Planner metaphor mode" not in plot_prompt
+    assert "Return the same detailed textual figure-description output" in diagram_prompt
+    assert "Do not output SVG, code, image markup" in diagram_prompt
+
+
+def test_planner_agent_uses_exp_config_metaphor_flag_for_diagrams(tmp_path):
+    exp_config = ExpConfig(
+        dataset_name="PaperBananaBench",
+        task_name="diagram",
+        planner_metaphor=True,
+        work_dir=Path(tmp_path),
+        main_model_name="test-main",
+        image_gen_model_name="test-image",
+    )
+
+    planner = PlannerAgent(exp_config=exp_config)
+
+    assert planner.system_prompt == (
+        DIAGRAM_PLANNER_AGENT_SYSTEM_PROMPT + DIAGRAM_PLANNER_METAPHOR_SUPPLEMENT
+    )
+
+
+def test_planner_agent_ignores_metaphor_flag_for_plots(tmp_path):
+    exp_config = ExpConfig(
+        dataset_name="PaperBananaBench",
+        task_name="plot",
+        planner_metaphor=True,
+        work_dir=Path(tmp_path),
+        main_model_name="test-main",
+        image_gen_model_name="test-image",
+    )
+
+    planner = PlannerAgent(exp_config=exp_config)
+
+    assert planner.system_prompt == PLOT_PLANNER_AGENT_SYSTEM_PROMPT
+    assert "Planner metaphor mode" not in planner.system_prompt

--- a/utils/config.py
+++ b/utils/config.py
@@ -33,6 +33,7 @@ class ExpConfig:
     temperature: float = 1.0
     exp_mode: str = ""
     retrieval_setting: Literal["auto", "manual", "random", "none"] = "auto"
+    planner_metaphor: bool = False
     max_critic_rounds: int = 3
     main_model_name: str = ""
     image_gen_model_name: str = ""


### PR DESCRIPTION
## Summary
- add `--planner-metaphor` and `ExpConfig.planner_metaphor`, defaulting to false
- add a diagram-only Planner prompt supplement that asks for a compact visual metaphor before the normal detailed description
- keep the default Planner prompt unchanged and ignore the metaphor flag for plot tasks

Fixes #32.

## Validation
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. /Users/jeff/Codex_projects/PaperBanana/.venv/bin/python -m pytest -q -p no:cacheprovider tests
- git diff origin/main --check