### PR TITLE
Add critic controls and agentic critic mode

### DIFF
--- a/agents/critic_agent.py
+++ b/agents/critic_agent.py
@@ -24,6 +24,7 @@ from PIL import Image
 import json_repair
 
 from utils import generation_utils
+from utils.config import load_style_guide_for_task
 from .base_agent import BaseAgent
 
 
@@ -49,6 +50,64 @@ class CriticAgent(BaseAgent):
                 "critique_target": "Target Diagram for Critique:",
                 "context_labels": ["Methodology Section", "Figure Caption"],
             }
+
+    @staticmethod
+    def _extract_agentic_evidence(response: Any) -> Dict[str, Any]:
+        evidence = {
+            "response_text": "",
+            "executable_code": [],
+            "code_execution_result": [],
+        }
+        text_parts = []
+        for candidate in getattr(response, "candidates", []) or []:
+            content = getattr(candidate, "content", None)
+            for part in getattr(content, "parts", []) or []:
+                text = getattr(part, "text", None)
+                if text:
+                    text_parts.append(text)
+
+                executable_code = getattr(part, "executable_code", None)
+                if executable_code is not None:
+                    evidence["executable_code"].append({
+                        "language": str(getattr(executable_code, "language", "") or ""),
+                        "code": getattr(executable_code, "code", "") or "",
+                    })
+
+                code_result = getattr(part, "code_execution_result", None)
+                if code_result is not None:
+                    evidence["code_execution_result"].append({
+                        "outcome": str(getattr(code_result, "outcome", "") or ""),
+                        "output": getattr(code_result, "output", "") or "",
+                    })
+
+        evidence["response_text"] = "\n".join(text_parts).strip()
+        return evidence
+
+    async def _call_agentic_critic(self, content_list, round_idx: int, task_name: str) -> tuple[str, Dict[str, Any]]:
+        if generation_utils.gemini_client is None:
+            raise RuntimeError(
+                "agentic_critic requires an initialized Gemini client. "
+                "Set GOOGLE_API_KEY or api_keys.google_api_key."
+            )
+
+        response = await generation_utils.gemini_client.aio.models.generate_content(
+            model=self.model_name,
+            contents=generation_utils._convert_to_gemini_parts(content_list),
+            config=types.GenerateContentConfig(
+                system_instruction=self.system_prompt,
+                temperature=self.exp_config.temperature,
+                candidate_count=1,
+                max_output_tokens=50000,
+                tools=[types.Tool(code_execution=types.ToolCodeExecution())],
+            ),
+        )
+        evidence = self._extract_agentic_evidence(response)
+        return evidence["response_text"], {
+            "round": round_idx,
+            "task_name": task_name,
+            "model_name": self.model_name,
+            **evidence,
+        }
 
     async def process(self, data: Dict[str, Any], source: str = "stylist") -> Dict[str, Any]:
         """
@@ -90,6 +149,7 @@ class CriticAgent(BaseAgent):
         if isinstance(content, (dict, list)):
             content = json.dumps(content)
         visual_intent = data["visual_intent"]
+        style_guide = load_style_guide_for_task(self.exp_config.work_dir, task_name)
         content_list = [{"type": "text", "text": cfg["critique_target"]}]
         
         if image_base64 and len(image_base64) > 100:
@@ -110,24 +170,37 @@ class CriticAgent(BaseAgent):
 
         content_list.append({
             "type": "text",
-            "text": f"Detailed Description: {detailed_description}\n{cfg['context_labels'][0]}: {content}\n{cfg['context_labels'][1]}: {visual_intent}\nYour Output:",
+            "text": (
+                f"Detailed Description: {detailed_description}\n"
+                f"Style Guidelines: {style_guide}\n"
+                f"{cfg['context_labels'][0]}: {content}\n"
+                f"{cfg['context_labels'][1]}: {visual_intent}\n"
+                "Your Output:"
+            ),
         })
 
-        response_list = await generation_utils.call_model_with_retry_async(
-            model_name=self.model_name,
-            contents=content_list,
-            config=types.GenerateContentConfig(
-                system_instruction=self.system_prompt,
-                temperature=self.exp_config.temperature,
-                candidate_count=1,
-                max_output_tokens=50000,
-            ),
-            max_attempts=5,
-            retry_delay=5,
-        )
+        if self.exp_config.agentic_critic:
+            cleaned_response, evidence = await self._call_agentic_critic(
+                content_list, round_idx=round_idx, task_name=task_name
+            )
+            data[f"target_{task_name}_critic_agentic_evidence{round_idx}"] = evidence
+        else:
+            response_list = await generation_utils.call_model_with_retry_async(
+                model_name=self.model_name,
+                contents=content_list,
+                config=types.GenerateContentConfig(
+                    system_instruction=self.system_prompt,
+                    temperature=self.exp_config.temperature,
+                    candidate_count=1,
+                    max_output_tokens=50000,
+                ),
+                max_attempts=5,
+                retry_delay=5,
+            )
+            cleaned_response = response_list[0]
         
         cleaned_response = (
-            response_list[0].replace("```json", "").replace("```", "").strip()
+            cleaned_response.replace("```json", "").replace("```", "").strip()
         )
         try:
             eval_result = json_repair.loads(cleaned_response)
@@ -176,6 +249,7 @@ Your Description should primarily be modifications based on the original descrip
 ## INPUT DATA
 -   **Target Diagram**: [The generated figure]
 -   **Detailed Description**: [The detailed description of the figure]
+-   **Style Guidelines**: [Task-specific NeurIPS 2025 style guidelines]
 -   **Methodology Section**: [Contextual content from the methodology section]
 -   **Figure Caption**: [Target figure caption]
 
@@ -220,6 +294,7 @@ You are also provided with the 'Detailed Description' corresponding to the curre
 ## INPUT DATA
 -   **Target Plot**: [The generated plot]
 -   **Detailed Description**: [The detailed description of the plot]
+-   **Style Guidelines**: [Task-specific NeurIPS 2025 style guidelines]
 -   **Raw Data**: [The raw data to be visualized]
 -   **Visual Intent**: [Visual intent of the desired plot]
 

--- a/agents/polish_agent.py
+++ b/agents/polish_agent.py
@@ -24,6 +24,7 @@ from google.genai import types
 from PIL import Image
 
 from utils import generation_utils, image_utils
+from utils.config import load_style_guide_for_task, style_guide_filename_for_task
 from .base_agent import BaseAgent
 
 
@@ -48,17 +49,16 @@ class PolishAgent(BaseAgent):
         
         # Task-specific configurations
         if self.exp_config.task_name == "plot":
-            self.style_guide_filename = "neurips2025_plot_style_guide.md"
             self.suggestion_system_prompt = PLOT_SUGGESTION_SYSTEM_PROMPT
             self.task_config = {
                 "task_name": "plot",
             }
         else:
-            self.style_guide_filename = "neurips2025_diagram_style_guide.md"
             self.suggestion_system_prompt = DIAGRAM_SUGGESTION_SYSTEM_PROMPT
             self.task_config = {
                 "task_name": "diagram",
             }
+        self.style_guide_filename = style_guide_filename_for_task(self.task_config["task_name"])
 
     async def _generate_suggestions(self, gt_image_b64: str, style_guide: str) -> str:
         """Step 1: Generate improvement suggestions based on style guide"""
@@ -119,12 +119,10 @@ class PolishAgent(BaseAgent):
             return data
         
         # Load style guide
-        style_guide_path = self.exp_config.work_dir / "style_guides" / self.style_guide_filename
         try:
-            with open(style_guide_path, "r", encoding="utf-8") as f:
-                style_guide = f.read()
+            style_guide = load_style_guide_for_task(self.exp_config.work_dir, task_name)
         except Exception as e:
-            print(f"❌ Error loading style guide from {style_guide_path}: {e}")
+            print(f"❌ Error loading style guide {self.style_guide_filename}: {e}")
             return data
             
         print(f"🎨 [Step 1] Generating suggestions for {task_name}...")

--- a/agents/stylist_agent.py
+++ b/agents/stylist_agent.py
@@ -25,6 +25,7 @@ import base64, io, asyncio
 from PIL import Image
 
 from utils import generation_utils
+from utils.config import load_style_guide_for_task
 from .base_agent import BaseAgent
 
 
@@ -62,8 +63,7 @@ class StylistAgent(BaseAgent):
         
         detailed_description = data[input_desc_key]
         
-        with open(self.exp_config.work_dir / f"style_guides/neurips2025_{task_name}_style_guide.md", "r", encoding="utf-8") as f:
-            style_guide = f.read()
+        style_guide = load_style_guide_for_task(self.exp_config.work_dir, task_name)
         
         user_prompt = f"Detailed Description: {detailed_description}\nStyle Guidelines: {style_guide}\n"
         raw_content = data['content']

--- a/configs/model_config.template.yaml
+++ b/configs/model_config.template.yaml
@@ -18,6 +18,7 @@
 defaults:
   main_model_name: "gemini-3.1-pro-preview"
   image_gen_model_name: "gemini-3.1-flash-image-preview"
+  agentic_critic: false
   
 # API Keys. If you are using all gemini models, you can leave the other keys empty.
 api_keys:

--- a/main.py
+++ b/main.py
@@ -77,6 +77,11 @@ async def main():
         help="maximum number of critic rounds (default: 3)",
     )
     parser.add_argument(
+        "--agentic-critic",
+        action="store_true",
+        help="enable Gemini code_execution Critic path (default: disabled)",
+    )
+    parser.add_argument(
         "--main_model_name",
         type=str,
         default="",
@@ -97,6 +102,7 @@ async def main():
         exp_mode=args.exp_mode,
         retrieval_setting=args.retrieval_setting,
         max_critic_rounds=args.max_critic_rounds,
+        agentic_critic=args.agentic_critic,
         main_model_name=args.main_model_name,
         image_gen_model_name=args.image_gen_model_name,
         work_dir=Path(__file__).parent,

--- a/tests/test_agentic_critic.py
+++ b/tests/test_agentic_critic.py
@@ -1,0 +1,275 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from agents.critic_agent import CriticAgent
+from agents.stylist_agent import StylistAgent
+from utils import generation_utils
+from utils.config import ExpConfig, style_guide_filename_for_task
+from utils.paperviz_processor import PaperVizProcessor
+
+
+def _write_style_guides(work_dir):
+    style_dir = work_dir / "style_guides"
+    style_dir.mkdir(parents=True)
+    (style_dir / "neurips2025_diagram_style_guide.md").write_text(
+        "DIAGRAM_STYLE_GUIDE_SENTINEL",
+        encoding="utf-8",
+    )
+    (style_dir / "neurips2025_plot_style_guide.md").write_text(
+        "PLOT_STYLE_GUIDE_SENTINEL",
+        encoding="utf-8",
+    )
+
+
+def _diagram_data():
+    return {
+        "target_diagram_desc0": "Initial planner description",
+        "target_diagram_desc0_base64_jpg": "",
+        "content": "method content",
+        "visual_intent": "figure caption",
+    }
+
+
+def _config(tmp_path, **kwargs):
+    _write_style_guides(tmp_path)
+    defaults = {
+        "dataset_name": "PaperBananaBench",
+        "task_name": "diagram",
+        "exp_mode": "demo_planner_critic",
+        "main_model_name": "gemini-2.5-pro",
+        "image_gen_model_name": "gemini-2.5-flash-image-preview",
+        "work_dir": tmp_path,
+        "timestamp": "test",
+    }
+    defaults.update(kwargs)
+    return ExpConfig(**defaults)
+
+
+def test_style_guide_filename_normalizes_task_aliases():
+    assert style_guide_filename_for_task("diagram") == "neurips2025_diagram_style_guide.md"
+    assert style_guide_filename_for_task("plots") == "neurips2025_plot_style_guide.md"
+
+
+def test_agentic_critic_rejects_non_gemini_model(tmp_path):
+    _write_style_guides(tmp_path)
+    with pytest.raises(ValueError, match="agentic_critic requires"):
+        ExpConfig(
+            dataset_name="PaperBananaBench",
+            task_name="diagram",
+            agentic_critic=True,
+            main_model_name="claude-3-5-sonnet",
+            image_gen_model_name="gemini-2.5-flash-image-preview",
+            work_dir=tmp_path,
+            timestamp="test",
+        )
+
+
+def test_agentic_critic_can_be_enabled_from_model_config(tmp_path):
+    _write_style_guides(tmp_path)
+    config_dir = tmp_path / "configs"
+    config_dir.mkdir()
+    (config_dir / "model_config.yaml").write_text(
+        "\n".join([
+            "defaults:",
+            '  main_model_name: "gemini-2.5-pro"',
+            '  image_gen_model_name: "gemini-2.5-flash-image-preview"',
+            "  agentic_critic: true",
+        ]),
+        encoding="utf-8",
+    )
+
+    exp_config = ExpConfig(
+        dataset_name="PaperBananaBench",
+        task_name="diagram",
+        work_dir=tmp_path,
+        timestamp="test",
+    )
+
+    assert exp_config.agentic_critic is True
+    assert exp_config.main_model_name == "gemini-2.5-pro"
+
+
+def test_default_critic_path_uses_router_and_loads_task_style_guide(tmp_path, monkeypatch):
+    exp_config = _config(tmp_path, agentic_critic=False)
+    captured = {}
+
+    async def fake_router(model_name, contents, config, max_attempts, retry_delay, error_context=""):
+        captured["model_name"] = model_name
+        captured["contents"] = contents
+        return [
+            '{"critic_suggestions":"No changes needed.","revised_description":"No changes needed."}'
+        ]
+
+    class FailGeminiClient:
+        aio = SimpleNamespace(
+            models=SimpleNamespace(
+                generate_content=lambda *args, **kwargs: (_ for _ in ()).throw(
+                    AssertionError("default critic path should not call Gemini directly")
+                )
+            )
+        )
+
+    monkeypatch.setattr(generation_utils, "call_model_with_retry_async", fake_router)
+    monkeypatch.setattr(generation_utils, "gemini_client", FailGeminiClient())
+
+    result = asyncio.run(CriticAgent(exp_config=exp_config).process(_diagram_data(), source="planner"))
+
+    assert captured["model_name"] == "gemini-2.5-pro"
+    assert "DIAGRAM_STYLE_GUIDE_SENTINEL" in captured["contents"][-1]["text"]
+    assert result["target_diagram_critic_suggestions0"] == "No changes needed."
+    assert result["target_diagram_critic_desc0"] == "Initial planner description"
+    assert "target_diagram_critic_agentic_evidence0" not in result
+
+
+def test_stylist_loads_task_specific_style_guide(tmp_path, monkeypatch):
+    exp_config = _config(tmp_path, task_name="plot")
+    captured = {}
+
+    async def fake_router(model_name, contents, config, max_attempts, retry_delay, error_context=""):
+        captured["prompt"] = contents[0]["text"]
+        return ["Styled plot description"]
+
+    monkeypatch.setattr(generation_utils, "call_model_with_retry_async", fake_router)
+    data = {
+        "target_plot_desc0": "Initial plot description",
+        "content": {"x": [1, 2], "y": [3, 4]},
+        "visual_intent": "show trend",
+    }
+
+    result = asyncio.run(StylistAgent(exp_config=exp_config).process(data))
+
+    assert "PLOT_STYLE_GUIDE_SENTINEL" in captured["prompt"]
+    assert "DIAGRAM_STYLE_GUIDE_SENTINEL" not in captured["prompt"]
+    assert result["target_plot_stylist_desc0"] == "Styled plot description"
+
+
+def test_zero_critic_rounds_bypasses_critic_and_keeps_planner_eval_image(tmp_path):
+    exp_config = _config(tmp_path, max_critic_rounds=0)
+
+    class FailCritic:
+        async def process(self, data, source="stylist"):
+            raise AssertionError("critic should not run when max_rounds is 0")
+
+    class FailVisualizer:
+        async def process(self, data):
+            raise AssertionError("visualizer should not rerun when max_rounds is 0")
+
+    processor = PaperVizProcessor(
+        exp_config=exp_config,
+        vanilla_agent=None,
+        planner_agent=None,
+        visualizer_agent=FailVisualizer(),
+        stylist_agent=None,
+        critic_agent=FailCritic(),
+        retriever_agent=None,
+        polish_agent=None,
+    )
+    data = {"target_diagram_desc0_base64_jpg": "planner-image"}
+
+    result = asyncio.run(
+        processor._run_critic_iterations(data, "diagram", max_rounds=0, source="planner")
+    )
+
+    assert result["eval_image_field"] == "target_diagram_desc0_base64_jpg"
+    assert "current_critic_round" not in result
+
+
+def test_zero_critic_rounds_from_config_bypasses_planner_critic_mode(tmp_path):
+    exp_config = _config(tmp_path, max_critic_rounds=0)
+
+    class FakeRetriever:
+        async def process(self, data, retrieval_setting="auto"):
+            data["top10_references"] = []
+            return data
+
+    class FakePlanner:
+        async def process(self, data):
+            data["target_diagram_desc0"] = "planned description"
+            return data
+
+    class FakeVisualizer:
+        async def process(self, data):
+            data["target_diagram_desc0_base64_jpg"] = "planner-image"
+            return data
+
+    class FailCritic:
+        async def process(self, data, source="stylist"):
+            raise AssertionError("critic should not run when config max_critic_rounds is 0")
+
+    processor = PaperVizProcessor(
+        exp_config=exp_config,
+        vanilla_agent=None,
+        planner_agent=FakePlanner(),
+        visualizer_agent=FakeVisualizer(),
+        stylist_agent=None,
+        critic_agent=FailCritic(),
+        retriever_agent=FakeRetriever(),
+        polish_agent=None,
+    )
+    data = {"content": "method content", "visual_intent": "figure caption"}
+
+    result = asyncio.run(processor.process_single_query(data, do_eval=False))
+
+    assert result["eval_image_field"] == "target_diagram_desc0_base64_jpg"
+    assert "current_critic_round" not in result
+
+
+def test_agentic_critic_uses_gemini_code_execution_and_persists_evidence(tmp_path, monkeypatch):
+    exp_config = _config(tmp_path, agentic_critic=True)
+    captured = {}
+
+    class FakeModels:
+        async def generate_content(self, model, contents, config):
+            captured["model"] = model
+            captured["contents"] = contents
+            captured["config"] = config
+            return SimpleNamespace(
+                candidates=[
+                    SimpleNamespace(
+                        content=SimpleNamespace(
+                            parts=[
+                                SimpleNamespace(
+                                    executable_code=SimpleNamespace(
+                                        language="PYTHON",
+                                        code="print('checking layout')",
+                                    ),
+                                    text=None,
+                                    code_execution_result=None,
+                                ),
+                                SimpleNamespace(
+                                    code_execution_result=SimpleNamespace(
+                                        outcome="OUTCOME_OK",
+                                        output="checking layout\n",
+                                    ),
+                                    text=None,
+                                    executable_code=None,
+                                ),
+                                SimpleNamespace(
+                                    text=(
+                                        '{"critic_suggestions":"Tighten labels.",'
+                                        '"revised_description":"Revised diagram description"}'
+                                    ),
+                                    executable_code=None,
+                                    code_execution_result=None,
+                                ),
+                            ]
+                        )
+                    )
+                ]
+            )
+
+    fake_client = SimpleNamespace(aio=SimpleNamespace(models=FakeModels()))
+    monkeypatch.setattr(generation_utils, "gemini_client", fake_client)
+
+    result = asyncio.run(CriticAgent(exp_config=exp_config).process(_diagram_data(), source="planner"))
+
+    assert captured["model"] == "gemini-2.5-pro"
+    assert captured["config"].tools[0].code_execution is not None
+    assert result["target_diagram_critic_suggestions0"] == "Tighten labels."
+    assert result["target_diagram_critic_desc0"] == "Revised diagram description"
+    evidence = result["target_diagram_critic_agentic_evidence0"]
+    assert evidence["response_text"].startswith('{"critic_suggestions"')
+    assert evidence["executable_code"][0]["code"] == "print('checking layout')"
+    assert evidence["code_execution_result"][0]["output"] == "checking layout\n"

--- a/utils/config.py
+++ b/utils/config.py
@@ -23,6 +23,36 @@ from pathlib import Path
 from typing import Literal
 
 
+def normalize_task_name(task_name: str) -> Literal["diagram", "plot"]:
+    """Normalize user/config task names to canonical style-guide task names."""
+    normalized = (task_name or "").strip().lower()
+    if normalized in {"diagram", "diagrams"}:
+        return "diagram"
+    if normalized in {"plot", "plots"}:
+        return "plot"
+    raise ValueError(f"Unsupported task_name '{task_name}'. Expected 'diagram' or 'plot'.")
+
+
+def style_guide_filename_for_task(task_name: str) -> str:
+    return f"neurips2025_{normalize_task_name(task_name)}_style_guide.md"
+
+
+def style_guide_path_for_task(work_dir: Path, task_name: str) -> Path:
+    return Path(work_dir) / "style_guides" / style_guide_filename_for_task(task_name)
+
+
+def load_style_guide_for_task(work_dir: Path, task_name: str) -> str:
+    with open(style_guide_path_for_task(work_dir, task_name), "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def is_native_gemini_model(model_name: str) -> bool:
+    normalized = (model_name or "").strip()
+    if normalized.startswith("models/"):
+        normalized = normalized[len("models/"):]
+    return normalized.startswith("gemini-")
+
+
 @dataclass
 class ExpConfig:
     """Experiment configuration"""
@@ -34,6 +64,7 @@ class ExpConfig:
     exp_mode: str = ""
     retrieval_setting: Literal["auto", "manual", "random", "none"] = "auto"
     max_critic_rounds: int = 3
+    agentic_critic: bool = False
     main_model_name: str = ""
     image_gen_model_name: str = ""
     work_dir: Path = Path(__file__).parent.parent
@@ -44,6 +75,7 @@ class ExpConfig:
         os.environ["TZ"] = "America/Los_Angeles"  # set the timezone as you like
         if hasattr(time, "tzset"):
             time.tzset()  # Only available on Unix; no-op guard for Windows
+        self.task_name = normalize_task_name(self.task_name)
         
         # Fallback to yaml config if no model name provided
         if not self.main_model_name or not self.image_gen_model_name:
@@ -52,10 +84,13 @@ class ExpConfig:
             if config_path.exists():
                 with open(config_path, "r", encoding="utf-8") as f:
                     model_config_data = yaml.safe_load(f) or {}
+                    defaults = model_config_data.get("defaults", {})
                     if not self.main_model_name:
-                        self.main_model_name = model_config_data.get("defaults", {}).get("main_model_name", "")
+                        self.main_model_name = defaults.get("main_model_name", "")
                     if not self.image_gen_model_name:
-                        self.image_gen_model_name = model_config_data.get("defaults", {}).get("image_gen_model_name", "")
+                        self.image_gen_model_name = defaults.get("image_gen_model_name", "")
+                    if not self.agentic_critic:
+                        self.agentic_critic = bool(defaults.get("agentic_critic", False))
         # Fallback to environment variables
         if not self.main_model_name:
             self.main_model_name = os.environ.get("MAIN_MODEL_NAME", "")
@@ -70,6 +105,11 @@ class ExpConfig:
             self.image_gen_model_name = "gemini-3.1-flash-image-preview"
             print(f"Warning: image_gen_model_name not configured, falling back to '{self.image_gen_model_name}'. "
                   "Set it in configs/model_config.yaml or via --image-gen-model-name.")
+        if self.agentic_critic and not is_native_gemini_model(self.main_model_name):
+            raise ValueError(
+                "agentic_critic requires a native Gemini main_model_name because it uses "
+                "Gemini code_execution. Disable agentic_critic or choose a gemini-* model."
+            )
         self.timestamp = (
             time.strftime("%m%d_%H%M") if self.timestamp is None else self.timestamp
         )

--- a/utils/paperviz_processor.py
+++ b/utils/paperviz_processor.py
@@ -73,7 +73,12 @@ class PaperVizProcessor:
             current_best_image_key = f"target_{task_name}_desc0_base64_jpg"
         else: # default to stylist
             current_best_image_key = f"target_{task_name}_stylist_desc0_base64_jpg"
-            
+
+        max_rounds = max(0, int(max_rounds or 0))
+        if max_rounds == 0:
+            data["eval_image_field"] = current_best_image_key
+            return data
+
         for round_idx in range(max_rounds):
             data["current_critic_round"] = round_idx
             data = await self.critic_agent.process(data, source=source)
@@ -145,7 +150,7 @@ class PaperVizProcessor:
             data = await self.planner_agent.process(data)
             data = await self.visualizer_agent.process(data)
             # Use max_critic_rounds from data if available, otherwise default to 3
-            max_rounds = data.get("max_critic_rounds", 3)
+            max_rounds = data.get("max_critic_rounds", self.exp_config.max_critic_rounds)
             data = await self._run_critic_iterations(data, task_name, max_rounds=max_rounds, source="planner")
             if "demo" in exp_mode: do_eval = False
 
@@ -256,4 +261,3 @@ class PaperVizProcessor:
             data, task_name=exp_config.task_name, work_dir=exp_config.work_dir
         )
         return data
-


### PR DESCRIPTION
## Summary
- centralize task/style-guide normalization and load task-specific style guides for Stylist, Polish, and Critic
- allow `max_critic_rounds=0` to bypass the Critic loop cleanly
- add opt-in `--agentic-critic` / `ExpConfig.agentic_critic`, defaulting to false
- implement Gemini-only agentic Critic code-execution path and persist response text, executable code, and code execution result evidence
- keep the default Critic path on the normal router

Fixes #64.
Fixes #35.

## Validation
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. /Users/jeff/Codex_projects/PaperBanana/.venv/bin/python -m pytest -q -p no:cacheprovider tests
- git diff origin/main --check

Note: the agentic Critic path is covered with a fake Gemini client; no live Gemini code-execution call was made.