### PR TITLE
fix(skill): pass the requested figure size through to the pipeline

### DIFF
--- a/skill/run.py
+++ b/skill/run.py
@@ -29,6 +29,22 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
+from utils.legacy_generation_options import (  # noqa: E402
+    FIGURE_SIZE_TO_IMAGE_SIZE,
+    generation_additional_info,
+)
+
+FIGURE_SIZE_CHOICES = list(FIGURE_SIZE_TO_IMAGE_SIZE)
+
+
+def build_additional_info(args) -> dict:
+    """The per-candidate ``additional_info``, routed through the shared helper.
+
+    Kept as a named seam so the wiring can be tested. Building this dict inline
+    was the original defect: ``figure_size`` never reached the pipeline.
+    """
+    return generation_additional_info(args.aspect_ratio, args.figure_size)
+
 
 def ensure_model_config():
     """Copy model_config.template.yaml to model_config.yaml if missing."""
@@ -138,7 +154,7 @@ async def run(args):
             "caption": args.caption,
             "content": content,
             "visual_intent": args.caption,
-            "additional_info": {"rounded_ratio": args.aspect_ratio},
+            "additional_info": build_additional_info(args),
             "max_critic_rounds": args.max_critic_rounds,
         })
 
@@ -185,7 +201,8 @@ async def run(args):
         print(p)
 
 
-def main():
+def build_parser() -> argparse.ArgumentParser:
+    """The CLI surface, separated from main() so it can be exercised in tests."""
     parser = argparse.ArgumentParser(
         description="PaperBanana Skill: generate academic diagrams/plots from text"
     )
@@ -203,6 +220,11 @@ def main():
     parser.add_argument("--aspect-ratio", type=str, default="21:9",
                         choices=["21:9", "16:9", "3:2"],
                         help="Aspect ratio (default: 21:9)")
+    parser.add_argument("--figure-size", type=str, default=None,
+                        choices=FIGURE_SIZE_CHOICES,
+                        help="Target figure width. Selects the provider image-size "
+                             "tier (see FIGURE_SIZE_TO_IMAGE_SIZE). Omitted, the "
+                             "provider default applies, as before.")
     parser.add_argument("--max-critic-rounds", type=int, default=3,
                         help="Max critic refinement rounds (default: 3)")
     parser.add_argument("--num-candidates", type=int, default=10,
@@ -220,7 +242,11 @@ def main():
                         choices=["demo_full", "demo_planner_critic"],
                         help="Pipeline mode: demo_full (Retriever+Planner+Stylist+Visualizer+Critic) or demo_planner_critic (Retriever+Planner+Visualizer+Critic, no Stylist) (default: demo_full)")
 
-    args = parser.parse_args()
+    return parser
+
+
+def main():
+    args = build_parser().parse_args()
     asyncio.run(run(args))
 
 

--- a/tests/test_skill_run_figure_size.py
+++ b/tests/test_skill_run_figure_size.py
@@ -1,0 +1,92 @@
+"""The CLI's figure-size wiring.
+
+``generation_additional_info`` and ``image_size_for_figure_size`` are already
+covered in ``test_legacy_generation_options``. What was untested is whether
+``skill/run.py`` calls them: it built ``additional_info`` inline as
+``{"rounded_ratio": ...}``, so ``figure_size`` never reached the pipeline and
+``image_size_from_data`` fell back to its default tier no matter what the caller
+asked for. These tests pin the call path rather than the helper.
+
+Offline; no network and no model calls.
+"""
+
+import unittest
+
+from skill.run import FIGURE_SIZE_CHOICES, build_additional_info, build_parser
+from utils.legacy_generation_options import image_size_from_data
+
+
+BASE_ARGV = ["--content", "method text", "--caption", "Figure 1: overview"]
+
+
+def parse(*extra):
+    return build_parser().parse_args(BASE_ARGV + list(extra))
+
+
+def additional_info(*extra):
+    """Exactly what run() puts on each data dict.
+
+    Calls run.py's own builder rather than re-deriving it here. Re-deriving
+    makes these tests pass even with the wiring reverted, which is the very
+    defect they exist to catch.
+    """
+    return build_additional_info(parse(*extra))
+
+
+class FigureSizeArgumentTests(unittest.TestCase):
+    def test_the_flag_accepts_every_documented_tier(self) -> None:
+        for choice in FIGURE_SIZE_CHOICES:
+            with self.subTest(figure_size=choice):
+                self.assertEqual(parse("--figure-size", choice).figure_size, choice)
+
+    def test_an_unknown_size_is_rejected(self) -> None:
+        with self.assertRaises(SystemExit):
+            parse("--figure-size", "20cm")
+
+    def test_omitting_the_flag_keeps_the_previous_default(self) -> None:
+        self.assertIsNone(parse().figure_size)
+
+
+class AdditionalInfoWiringTests(unittest.TestCase):
+    """The regression itself: a requested figure size must reach the pipeline."""
+
+    def test_a_requested_size_reaches_additional_info(self) -> None:
+        info = additional_info("--figure-size", "14-17cm")
+
+        self.assertEqual(info["figure_size"], "14-17cm")
+        self.assertEqual(info["image_size"], "4k")
+
+    def test_the_agents_read_the_tier_back_out(self) -> None:
+        """Asserted at the boundary the agents actually use."""
+        info = additional_info("--figure-size", "7-9cm")
+
+        self.assertEqual(image_size_from_data({"additional_info": info}), "2k")
+
+    def test_omitting_the_flag_leaves_additional_info_unchanged(self) -> None:
+        """Purely additive: an existing invocation behaves exactly as before."""
+        info = additional_info()
+
+        self.assertEqual(info, {"rounded_ratio": parse().aspect_ratio})
+
+
+class CallSiteTests(unittest.TestCase):
+    """The seam is only useful if the data dict actually goes through it.
+
+    The unit tests above pin what ``build_additional_info`` returns. They cannot
+    see a future edit that inlines the dict again at the call site, which is
+    precisely how the original defect looked, so this checks the wiring itself.
+    """
+
+    def test_the_candidate_dict_is_built_through_the_helper(self) -> None:
+        import inspect
+
+        from skill import run as skill_run
+
+        source = inspect.getsource(skill_run.run)
+
+        self.assertIn("build_additional_info(args)", source)
+        self.assertNotIn('"rounded_ratio": args.aspect_ratio', source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The headless CLI cannot request a figure size, and silently renders at the fallback tier.

## The bug

`skill/run.py` builds each candidate's `additional_info` inline:

```python
"additional_info": {"rounded_ratio": args.aspect_ratio},
```

`figure_size` is never set, so `image_size_from_data` falls back to its default tier on every headless run no matter what the caller wants. There is also no `--figure-size` flag, so there is no way to ask for anything else.

The Gradio UI has always exposed this control — `app.py` passes `figure_size` into `generation_additional_info`, which sets both `figure_size` and the derived `image_size`. So this is CLI/UI parity rather than a new capability.

Notably `generation_additional_info` and `image_size_for_figure_size` already exist and are already covered by `tests/test_legacy_generation_options.py`, including a case asserting the `14-17cm` → `4k` mapping. Only the caller was wrong.

## The change

Adds `--figure-size` with the same choices the UI offers, and routes the dict through the existing helper.

**Purely additive.** The flag defaults to `None`, so an invocation that does not pass it produces byte-identical `additional_info` to before. There is a test asserting exactly that, because I did not want to change anyone's existing behaviour.

Two small behaviour-preserving extractions make the wiring testable at all: `build_parser()` out of `main()`, and `build_additional_info()` for the dict. `main()` previously constructed its parser inline, so there was no way to exercise the CLI surface from a test.

## Verification

Offline, `unittest` only, no new dependencies — matching the existing suite. 38 tests pass.

The tests deliberately pin the **call path** rather than the helper, since the helper was already correct and already covered. Mutation-checked in both directions:

- making `build_additional_info` ignore `figure_size` turns a test red
- inlining the dict at the call site again turns another red

Happy to drop the extractions and inline the test differently if you would rather keep `main()` as it was.