### PR TITLE
fix(skill): download the dataset archive that is actually published

### DIFF
--- a/skill/run.py
+++ b/skill/run.py
@@ -22,6 +22,8 @@ import asyncio
 import base64
 import shutil
 import sys
+import tempfile
+import zipfile
 from io import BytesIO
 from pathlib import Path
 
@@ -39,26 +41,87 @@ def ensure_model_config():
         shutil.copy2(template_path, config_path)
 
 
+DATASET_REPO = "dwzhu/PaperBananaBench"
+DATASET_ARCHIVE = "PaperBananaBench.zip"
+DATASET_ROOT = "PaperBananaBench"
+
+
+def dataset_task_dir(task_name: str) -> Path:
+    return PROJECT_ROOT / "data" / DATASET_ROOT / task_name
+
+
+def task_dir_usable(task_dir: Path) -> bool:
+    """Whether an extracted task directory is complete enough to retrieve from.
+
+    One definition, shared by the download short-circuit and the extraction's
+    keep-or-replace decision. Two copies of this that must agree is how a
+    half-populated directory ends up surviving forever.
+    """
+    return (task_dir / "ref.json").exists() and (task_dir / "images").is_dir()
+
+
 def ensure_dataset(task_name: str):
-    """Download PaperBananaBench data from HuggingFace if not present locally."""
-    data_dir = PROJECT_ROOT / "data" / "PaperBananaBench" / task_name
-    ref_path = data_dir / "ref.json"
-    images_dir = data_dir / "images"
-    if ref_path.exists() and images_dir.exists():
+    """Download PaperBananaBench data from HuggingFace if not present locally.
+
+    The dataset is published as a single ``PaperBananaBench.zip``, not as a
+    per-task directory tree, so ``allow_patterns=["<task>/*"]`` matched no files
+    and nothing was ever downloaded. The archive's internal root is
+    ``PaperBananaBench/``, so extracting it into ``data/`` produces exactly the
+    ``data/PaperBananaBench/<task>/ref.json`` and ``.../images/`` layout the
+    Retriever and Planner already expect, with each entry's ``path_to_gt_image``
+    resolving relative to its task directory unchanged.
+    """
+    if task_dir_usable(dataset_task_dir(task_name)):
         return
     try:
-        from huggingface_hub import snapshot_download
+        from huggingface_hub import hf_hub_download
     except ImportError:
         print("ERROR: huggingface_hub is required for automatic dataset download.\n"
               "Install it with: pip install huggingface_hub", file=sys.stderr)
         sys.exit(1)
-    print(f"Downloading PaperBananaBench/{task_name} from HuggingFace...")
-    snapshot_download(
-        "dwzhu/PaperBananaBench",
-        repo_type="dataset",
-        allow_patterns=[f"{task_name}/*"],
-        local_dir=str(PROJECT_ROOT / "data" / "PaperBananaBench"),
-    )
+
+    data_root = PROJECT_ROOT / "data"
+    data_root.mkdir(parents=True, exist_ok=True)
+    print(f"Downloading {DATASET_ARCHIVE} from HuggingFace...")
+
+    with tempfile.TemporaryDirectory(dir=str(data_root)) as staging:
+        staging = Path(staging)
+        archive = hf_hub_download(
+            DATASET_REPO,
+            DATASET_ARCHIVE,
+            repo_type="dataset",
+            local_dir=str(staging / "download"),
+        )
+        # Extract into staging and move into place, so an interrupted or corrupt
+        # extraction cannot leave a tree that satisfies the presence check above
+        # and silently disables retrieval on every later run.
+        extracted = staging / "extracted"
+        with zipfile.ZipFile(archive) as archive_file:
+            archive_file.extractall(extracted)
+
+        source = extracted / DATASET_ROOT
+        if not (source / task_name / "ref.json").exists():
+            raise RuntimeError(
+                f"{DATASET_ARCHIVE} did not contain {DATASET_ROOT}/{task_name}/ref.json; "
+                "the archive layout has changed and ensure_dataset needs updating"
+            )
+
+        destination = data_root / DATASET_ROOT
+        superseded = staging / "superseded"
+        for entry in source.iterdir():
+            target = destination / entry.name
+            if target.exists():
+                # Keep what is already usable; replace what is not. Skipping on
+                # mere existence strands a half-populated task directory: it
+                # never satisfies task_dir_usable, so every later run downloads
+                # and extracts the archive again and then discards the complete
+                # copy it just produced.
+                if target.is_dir() and task_dir_usable(target):
+                    continue
+                superseded.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(target), str(superseded / entry.name))
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(entry), str(target))
 
 
 def extract_final_image_b64(result: dict, exp_mode: str) -> str | None:

--- a/tests/test_skill_run_dataset.py
+++ b/tests/test_skill_run_dataset.py
@@ -1,0 +1,211 @@
+"""Dataset acquisition for the headless skill CLI.
+
+``ensure_dataset`` requested ``allow_patterns=["<task>/*"]`` from a repository
+that publishes a single ``PaperBananaBench.zip``, so the pattern matched no
+files, nothing was downloaded, and the ``ref.json`` + ``images/`` presence check
+could never be satisfied. Every run therefore re-attempted the download, and
+``RetrieverAgent`` silently downgraded ``auto``/``random`` to ``none`` because
+the reference file was absent.
+
+These tests pin the acquisition path. ``huggingface_hub`` is replaced with a
+fake that builds a real archive with the published layout, so extraction is
+exercised rather than stubbed. Offline; no test here opens a socket.
+"""
+
+import contextlib
+import io
+import json
+import sys
+import tempfile
+import types
+import unittest
+import unittest.mock
+import zipfile
+from pathlib import Path
+
+from skill import run as skill_run
+
+
+class FakeHub:
+    """Stands in for ``huggingface_hub``; records calls, never touches a socket."""
+
+    def __init__(self, *, side_effect=None, archive_root="PaperBananaBench",
+                 tasks=("diagram", "plot")) -> None:
+        self.calls: list[dict] = []
+        self.side_effect = side_effect
+        self.archive_root = archive_root
+        self.tasks = tasks
+
+    def hf_hub_download(self, repo_id, filename, **kwargs):
+        self.calls.append({"repo_id": repo_id, "filename": filename, **kwargs})
+        if self.side_effect is not None:
+            raise self.side_effect
+
+        local_dir = Path(kwargs.get("local_dir") or tempfile.mkdtemp())
+        local_dir.mkdir(parents=True, exist_ok=True)
+        archive = local_dir / filename
+        with zipfile.ZipFile(archive, "w") as archive_file:
+            for task in self.tasks:
+                base = f"{self.archive_root}/{task}"
+                archive_file.writestr(
+                    f"{base}/ref.json",
+                    json.dumps([{"id": "x", "path_to_gt_image": "images/x.jpg"}]),
+                )
+                archive_file.writestr(f"{base}/images/x.jpg", b"not-a-real-jpeg")
+        return str(archive)
+
+
+@contextlib.contextmanager
+def fake_hub(**kwargs):
+    hub = FakeHub(**kwargs)
+    module = types.ModuleType("huggingface_hub")
+    module.hf_hub_download = hub.hf_hub_download
+    saved = sys.modules.get("huggingface_hub")
+    sys.modules["huggingface_hub"] = module
+    try:
+        yield hub
+    finally:
+        if saved is None:
+            sys.modules.pop("huggingface_hub", None)
+        else:
+            sys.modules["huggingface_hub"] = saved
+
+
+class DatasetAcquisitionTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+        patcher = unittest.mock.patch.object(skill_run, "PROJECT_ROOT", self.tmp)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def acquire(self, task="diagram"):
+        with contextlib.redirect_stdout(io.StringIO()):
+            skill_run.ensure_dataset(task)
+
+    def task_dir(self, task="diagram") -> Path:
+        return self.tmp / "data" / "PaperBananaBench" / task
+
+
+class ExtractionTests(DatasetAcquisitionTestCase):
+    def test_extraction_produces_the_layout_the_retriever_reads(self) -> None:
+        with fake_hub():
+            self.acquire()
+
+        self.assertTrue((self.task_dir() / "ref.json").exists())
+        self.assertTrue((self.task_dir() / "images").is_dir())
+
+    def test_the_image_paths_in_ref_json_resolve_where_the_planner_looks(self) -> None:
+        """PlannerAgent opens <task>/<path_to_gt_image> with no guard."""
+        with fake_hub():
+            self.acquire()
+
+        entries = json.loads((self.task_dir() / "ref.json").read_text(encoding="utf-8"))
+        for entry in entries:
+            self.assertTrue((self.task_dir() / entry["path_to_gt_image"]).exists())
+
+    def test_a_second_run_makes_no_network_call(self) -> None:
+        with fake_hub() as first:
+            self.acquire()
+        self.assertEqual(len(first.calls), 1)
+
+        with fake_hub() as second:
+            self.acquire()
+        self.assertEqual(second.calls, [], "the presence check did not short-circuit")
+
+    def test_an_unexpected_archive_layout_raises_instead_of_half_landing(self) -> None:
+        with fake_hub(archive_root="SomethingElse"):
+            with self.assertRaises(RuntimeError):
+                self.acquire()
+
+        self.assertFalse(
+            task_dir_usable_via_module(self.task_dir()),
+            "a failed acquisition left a tree that satisfies the presence check",
+        )
+
+    def test_a_failed_download_leaves_nothing_usable_behind(self) -> None:
+        with fake_hub(side_effect=RuntimeError("network died")):
+            with self.assertRaises(RuntimeError):
+                self.acquire()
+
+        self.assertFalse(task_dir_usable_via_module(self.task_dir()))
+
+
+class IncompleteTaskDirectoryTests(DatasetAcquisitionTestCase):
+    """A half-populated task directory must be repaired, not stranded.
+
+    Skipping the move when the destination merely exists left such a directory
+    in place permanently: it never satisfied the presence check, so every later
+    run re-downloaded and re-extracted the archive and then discarded the
+    complete copy it had just produced.
+    """
+
+    def partial(self, *, ref: bool, images: bool) -> Path:
+        task_dir = self.task_dir()
+        task_dir.mkdir(parents=True)
+        if ref:
+            (task_dir / "ref.json").write_text("[]", encoding="utf-8")
+        if images:
+            (task_dir / "images").mkdir()
+        return task_dir
+
+    def test_a_task_dir_missing_images_is_repaired(self) -> None:
+        self.partial(ref=True, images=False)
+
+        with fake_hub():
+            self.acquire()
+
+        self.assertTrue(task_dir_usable_via_module(self.task_dir()))
+
+    def test_an_empty_task_dir_is_repaired(self) -> None:
+        self.partial(ref=False, images=False)
+
+        with fake_hub():
+            self.acquire()
+
+        self.assertTrue(task_dir_usable_via_module(self.task_dir()))
+
+    def test_repairing_stops_the_endless_re_download(self) -> None:
+        self.partial(ref=True, images=False)
+
+        with fake_hub() as first:
+            self.acquire()
+        self.assertEqual(len(first.calls), 1)
+
+        with fake_hub() as again:
+            self.acquire()
+        self.assertEqual(again.calls, [], "a repaired dataset downloaded a second time")
+
+    def test_an_already_complete_task_dir_is_left_alone(self) -> None:
+        task_dir = self.partial(ref=False, images=True)
+        (task_dir / "ref.json").write_text('["LOCAL"]', encoding="utf-8")
+
+        with fake_hub() as hub:
+            self.acquire()
+
+        self.assertEqual(hub.calls, [], "a complete dataset triggered a download")
+        self.assertIn("LOCAL", (task_dir / "ref.json").read_text(encoding="utf-8"))
+
+    def test_a_sibling_task_is_not_disturbed_while_repairing_another(self) -> None:
+        base = self.tmp / "data" / "PaperBananaBench"
+        (base / "plot" / "images").mkdir(parents=True)
+        (base / "plot" / "ref.json").write_text('["PLOT-LOCAL"]', encoding="utf-8")
+        self.partial(ref=True, images=False)
+
+        with fake_hub():
+            self.acquire()
+
+        self.assertTrue(task_dir_usable_via_module(self.task_dir()))
+        self.assertIn(
+            "PLOT-LOCAL", (base / "plot" / "ref.json").read_text(encoding="utf-8")
+        )
+
+
+def task_dir_usable_via_module(task_dir: Path) -> bool:
+    """Assert through the module's own predicate, not a copy of it."""
+    return skill_run.task_dir_usable(task_dir)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The headless CLI's reference retrieval has been inert: the dataset is never downloaded, and nothing reports that it wasn't.

## The bug

`ensure_dataset` asks for a per-task directory:

```python
snapshot_download(..., allow_patterns=[f"{task_name}/*"], ...)
```

but `dwzhu/PaperBananaBench` publishes exactly two files — `.gitattributes` and `PaperBananaBench.zip`. There is no `diagram/` or `plot/` directory, so the pattern matches **zero files**:

```
>>> list_repo_files("dwzhu/PaperBananaBench", repo_type="dataset")
['.gitattributes', 'PaperBananaBench.zip']
```

## Why it stays hidden

Nothing errors, so the failure cascades quietly. The `ref.json` + `images/` presence check can never be satisfied, so every run re-attempts the download. `RetrieverAgent` then finds no reference file and silently downgrades `auto`/`random` to `none`. Runs complete normally and report zero retrieved references.

The practical effect is that the Retriever stage does not run for headless CLI users, and the Planner/Stylist/Critic loop carries the whole result.

## The change

Fetch the archive and extract it into `data/`. The archive's internal root is `PaperBananaBench/`, so this yields exactly the `data/PaperBananaBench/<task>/ref.json` and `.../images/` layout the Retriever and Planner already expect — each entry's `path_to_gt_image` is `images/<name>.jpg` relative to its task directory, which is what `PlannerAgent` builds. **No downstream change was needed.**

Three robustness details, each a failure mode I actually hit while testing:

- **Staged extraction**, moved into place, so an interrupted or corrupt run cannot leave a tree that satisfies the presence check and silently disables retrieval on every later run.
- **An unexpected archive root raises** rather than half-landing, so a future layout change surfaces instead of degrading quietly.
- **Keep-or-replace on usability, not existence.** Skipping when the destination merely exists strands a half-populated task directory permanently: it never satisfies the presence check, so every later run re-downloads and re-extracts the archive and then discards the complete copy it just produced.

## Verification

Against the live repository: **12.1s**, 298 reference entries and 610 images for the diagram task.

Tests use a fake `huggingface_hub` that builds a real archive with the published layout, so extraction is exercised rather than stubbed. Offline, `unittest` only, no new dependencies, 41 tests pass.

Mutation-checked — each of these turns tests red:
- restoring the original `allow_patterns` call
- skipping on mere existence instead of usability
- dropping the archive-layout guard

## Note

Independent of #80; the two touch different functions and can land in either order. Happy to adjust the scope if you would prefer the robustness handling split out from the download fix.